### PR TITLE
Added support for PHPUnit 10 and 12.

### DIFF
--- a/.github/workflows/test-php.yml
+++ b/.github/workflows/test-php.yml
@@ -18,11 +18,20 @@ on:
 
 jobs:
   test-php:
+    name: Test PHP ${{ matrix.php-versions }}, PHPUnit ${{ matrix.phpunit-versions }}
     runs-on: ubuntu-latest
 
     strategy:
       matrix:
         php-versions: ['8.2', '8.3', '8.4', '8.5']
+        phpunit-versions: ['11']
+        include:
+          - php-versions: '8.3'
+            phpunit-versions: '12'
+          - php-versions: '8.4'
+            phpunit-versions: '12'
+          - php-versions: '8.5'
+            phpunit-versions: '12'
 
     steps:
       - name: Checkout code
@@ -40,6 +49,11 @@ jobs:
           php-version: ${{ matrix.php-versions }}
           coverage: pcov
           ini-values: pcov.directory=.
+
+      - name: Modify composer.json for PHPUnit version
+        run: |
+          PHPUNIT_CONSTRAINT="^${{ matrix.phpunit-versions || '10' }}"
+          composer require --no-update "phpunit/phpunit:${PHPUNIT_CONSTRAINT}"
 
       - name: Install dependencies
         run: composer install ${{ matrix.php-versions == '8.5' && '--ignore-platform-reqs' || '' }}
@@ -60,7 +74,7 @@ jobs:
       - name: Upload coverage report as an artifact
         uses: actions/upload-artifact@v4
         with:
-          name: ${{github.job}}-code-coverage-report-${{ matrix.php-versions }}
+          name: ${{github.job}}-code-coverage-report-php-${{ matrix.php-versions }}-phpunit-${{ matrix.phpunit-versions }}
           path: .logs
           include-hidden-files: true
           if-no-files-found: error

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     },
     "require": {
         "php": ">=8.2",
-        "phpunit/phpunit": "^11",
+        "phpunit/phpunit": "^11 || ^12",
         "symfony/filesystem": "^7.2",
         "symfony/finder": "^7.2",
         "symfony/process": "^7.2"

--- a/tests/Unit/ApplicationTraitTest.php
+++ b/tests/Unit/ApplicationTraitTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace AlexSkrypnyk\PhpunitHelpers\Tests\Unit;
 
+use PHPUnit\Framework\Attributes\CoversTrait;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Input\InputInterface;
@@ -14,11 +15,10 @@ use AlexSkrypnyk\PhpunitHelpers\Tests\Fixtures\Application\Command\GreetingComma
 use AlexSkrypnyk\PhpunitHelpers\Tests\Fixtures\Application\Command\ErrorOutputCommand;
 use AlexSkrypnyk\PhpunitHelpers\Traits\ApplicationTrait;
 use AlexSkrypnyk\PhpunitHelpers\UnitTestCase;
-use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\ExpectationFailedException;
 
-#[CoversClass(ApplicationTrait::class)]
+#[CoversTrait(ApplicationTrait::class)]
 class ApplicationTraitTest extends UnitTestCase {
 
   use ApplicationTrait;

--- a/tests/Unit/AssertArrayTraitTest.php
+++ b/tests/Unit/AssertArrayTraitTest.php
@@ -6,10 +6,10 @@ namespace AlexSkrypnyk\PhpunitHelpers\Tests\Unit;
 
 use PHPUnit\Framework\AssertionFailedError;
 use AlexSkrypnyk\PhpunitHelpers\Traits\AssertArrayTrait;
-use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\CoversTrait;
 use PHPUnit\Framework\TestCase;
 
-#[CoversClass(AssertArrayTrait::class)]
+#[CoversTrait(AssertArrayTrait::class)]
 class AssertArrayTraitTest extends TestCase {
 
   use AssertArrayTrait;

--- a/tests/Unit/EnvTraitTest.php
+++ b/tests/Unit/EnvTraitTest.php
@@ -5,10 +5,10 @@ declare(strict_types=1);
 namespace AlexSkrypnyk\PhpunitHelpers\Tests\Unit;
 
 use AlexSkrypnyk\PhpunitHelpers\Traits\EnvTrait;
-use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\CoversTrait;
 use PHPUnit\Framework\TestCase;
 
-#[CoversClass(EnvTrait::class)]
+#[CoversTrait(EnvTrait::class)]
 class EnvTraitTest extends TestCase {
 
   use EnvTrait;

--- a/tests/Unit/LocationsTraitTest.php
+++ b/tests/Unit/LocationsTraitTest.php
@@ -5,12 +5,12 @@ declare(strict_types=1);
 namespace AlexSkrypnyk\PhpunitHelpers\Tests\Unit;
 
 use AlexSkrypnyk\PhpunitHelpers\Traits\LocationsTrait;
-use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\CoversTrait;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Filesystem\Filesystem;
 
-#[CoversClass(LocationsTrait::class)]
+#[CoversTrait(LocationsTrait::class)]
 class LocationsTraitTest extends TestCase {
 
   use LocationsTrait;

--- a/tests/Unit/ProcessTraitTest.php
+++ b/tests/Unit/ProcessTraitTest.php
@@ -4,13 +4,13 @@ declare(strict_types=1);
 
 namespace AlexSkrypnyk\PhpunitHelpers\Tests\Unit;
 
+use PHPUnit\Framework\Attributes\CoversTrait;
 use PHPUnit\Framework\ExpectationFailedException;
 use AlexSkrypnyk\PhpunitHelpers\Traits\ProcessTrait;
 use AlexSkrypnyk\PhpunitHelpers\UnitTestCase;
-use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 
-#[CoversClass(ProcessTrait::class)]
+#[CoversTrait(ProcessTrait::class)]
 class ProcessTraitTest extends UnitTestCase {
 
   use ProcessTrait;

--- a/tests/Unit/ReflectionTraitTest.php
+++ b/tests/Unit/ReflectionTraitTest.php
@@ -5,10 +5,10 @@ declare(strict_types=1);
 namespace AlexSkrypnyk\PhpunitHelpers\Tests\Unit;
 
 use AlexSkrypnyk\PhpunitHelpers\Traits\ReflectionTrait;
-use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\CoversTrait;
 use PHPUnit\Framework\TestCase;
 
-#[CoversClass(ReflectionTrait::class)]
+#[CoversTrait(ReflectionTrait::class)]
 class ReflectionTraitTest extends TestCase {
 
   use ReflectionTrait;

--- a/tests/Unit/SerializableClosureTraitTest.php
+++ b/tests/Unit/SerializableClosureTraitTest.php
@@ -6,10 +6,10 @@ namespace AlexSkrypnyk\PhpunitHelpers\Tests\Unit;
 
 use AlexSkrypnyk\PhpunitHelpers\Traits\SerializableClosureTrait;
 use Laravel\SerializableClosure\SerializableClosure;
-use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\CoversTrait;
 use PHPUnit\Framework\TestCase;
 
-#[CoversClass(SerializableClosureTrait::class)]
+#[CoversTrait(SerializableClosureTrait::class)]
 class SerializableClosureTraitTest extends TestCase {
 
   use SerializableClosureTrait;

--- a/tests/Unit/TuiTraitTest.php
+++ b/tests/Unit/TuiTraitTest.php
@@ -5,11 +5,11 @@ declare(strict_types=1);
 namespace AlexSkrypnyk\PhpunitHelpers\Tests\Unit;
 
 use AlexSkrypnyk\PhpunitHelpers\Traits\TuiTrait;
-use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\CoversTrait;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
-#[CoversClass(TuiTrait::class)]
+#[CoversTrait(TuiTrait::class)]
 class TuiTraitTest extends TestCase {
 
   use TuiTrait;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Enhanced automated testing to cover PHP versions 8.2 through 8.5 with PHPUnit versions 11 and 12, improving compatibility checks.
  - Improved workflow artifact naming for clearer traceability of test results.
- **New Features**
  - Expanded supported PHPUnit versions to include 11 and 12.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->