### PR TITLE
Updated symfony deps to allow using v6 + CI.

### DIFF
--- a/.github/workflows/test-php.yml
+++ b/.github/workflows/test-php.yml
@@ -18,20 +18,33 @@ on:
 
 jobs:
   test-php:
-    name: Test PHP ${{ matrix.php-versions }}, PHPUnit ${{ matrix.phpunit-versions }}
+    name: Test PHP ${{ matrix.php-versions }}, PHPUnit ${{ matrix.phpunit-versions }}, Deps ${{ matrix.dependency-preference }}
     runs-on: ubuntu-latest
 
     strategy:
       matrix:
         php-versions: ['8.2', '8.3', '8.4', '8.5']
         phpunit-versions: ['11']
+        dependency-preference: ['normal', 'lowest']
         include:
           - php-versions: '8.3'
             phpunit-versions: '12'
+            dependency-preference: 'normal'
+          - php-versions: '8.3'
+            phpunit-versions: '12'
+            dependency-preference: 'lowest'
           - php-versions: '8.4'
             phpunit-versions: '12'
+            dependency-preference: 'normal'
+          - php-versions: '8.4'
+            phpunit-versions: '12'
+            dependency-preference: 'lowest'
           - php-versions: '8.5'
             phpunit-versions: '12'
+            dependency-preference: 'normal'
+          - php-versions: '8.5'
+            phpunit-versions: '12'
+            dependency-preference: 'lowest'
 
     steps:
       - name: Checkout code
@@ -56,7 +69,12 @@ jobs:
           composer require --no-update "phpunit/phpunit:${PHPUNIT_CONSTRAINT}"
 
       - name: Install dependencies
-        run: composer install ${{ matrix.php-versions == '8.5' && '--ignore-platform-reqs' || '' }}
+        run: |
+          if [[ "${{ matrix.dependency-preference }}" == "lowest" ]]; then
+            composer update --prefer-lowest --prefer-stable ${{ matrix.php-versions == '8.5' && '--ignore-platform-reqs' || '' }}
+          else
+            composer install ${{ matrix.php-versions == '8.5' && '--ignore-platform-reqs' || '' }}
+          fi
 
       - name: Validate composer.json
         run: |
@@ -64,24 +82,32 @@ jobs:
           composer normalize --dry-run
 
       - name: Check coding standards
+        if: matrix.php-versions == '8.3' && matrix.dependency-preference == 'normal'
         run: composer lint
         continue-on-error: ${{ vars.CI_LINT_IGNORE_FAILURE == '1' }}
 
-      - name: Run tests
+      - name: Run tests with coverage
+        if: matrix.phpunit-versions == '11'
         run: composer test-coverage
         continue-on-error: ${{ vars.CI_TEST_IGNORE_FAILURE == '1' }}
 
+      - name: Run tests without coverage
+        if: matrix.phpunit-versions != '11'
+        run: composer test
+        continue-on-error: ${{ vars.CI_TEST_IGNORE_FAILURE == '1' }}
+
       - name: Upload coverage report as an artifact
+        if: matrix.phpunit-versions == '11'
         uses: actions/upload-artifact@v4
         with:
-          name: ${{github.job}}-code-coverage-report-php-${{ matrix.php-versions }}-phpunit-${{ matrix.phpunit-versions }}
+          name: ${{github.job}}-code-coverage-report-php-${{ matrix.php-versions }}-phpunit-${{ matrix.phpunit-versions }}-deps-${{ matrix.dependency-preference }}
           path: .logs
           include-hidden-files: true
           if-no-files-found: error
 
       - name: Upload test results to Codecov
+        if: matrix.phpunit-versions == '11' && env.CODECOV_TOKEN != ''
         uses: codecov/test-results-action@v1
-        if: ${{ env.CODECOV_TOKEN != '' }}
         with:
           files: .logs/junit.xml
           fail_ci_if_error: true
@@ -89,8 +115,8 @@ jobs:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Upload coverage report to Codecov
+        if: matrix.phpunit-versions == '11' && env.CODECOV_TOKEN != ''
         uses: codecov/codecov-action@v5
-        if: ${{ env.CODECOV_TOKEN != '' }}
         with:
           files: .logs/cobertura.xml
           fail_ci_if_error: true

--- a/composer.json
+++ b/composer.json
@@ -20,8 +20,8 @@
         "php": ">=8.2",
         "phpunit/phpunit": "^11 || ^12",
         "symfony/filesystem": "^7.2",
-        "symfony/finder": "^7.2",
-        "symfony/process": "^7.2"
+        "symfony/finder": "^6.4 || ^7.2",
+        "symfony/process": "^6.4 || ^7.2"
     },
     "require-dev": {
         "dealerdirect/phpcodesniffer-composer-installer": "^1",
@@ -30,7 +30,8 @@
         "laravel/serializable-closure": "^2.0",
         "phpstan/phpstan": "^2",
         "rector/rector": "^2",
-        "symfony/console": "^7.2"
+        "squizlabs/php_codesniffer": "^3.7",
+        "symfony/console": "^6.4 || ^7.2"
     },
     "minimum-stability": "stable",
     "prefer-stable": true,

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -12,7 +12,7 @@
          displayDetailsOnTestsThatTriggerErrors="true"
          displayDetailsOnTestsThatTriggerNotices="true"
          displayDetailsOnTestsThatTriggerDeprecations="true"
-         displayDetailsOnPhpunitDeprecations="true">
+         >
     <testsuites>
         <testsuite name="default">
             <directory>tests</directory>
@@ -20,7 +20,7 @@
     </testsuites>
     <source restrictNotices="true"
             restrictWarnings="true"
-            ignoreIndirectDeprecations="true">
+            >
         <include>
             <directory>src</directory>
         </include>

--- a/tests/Unit/ApplicationTraitTest.php
+++ b/tests/Unit/ApplicationTraitTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace AlexSkrypnyk\PhpunitHelpers\Tests\Unit;
 
-use PHPUnit\Framework\Attributes\CoversTrait;
+use PHPUnit\Framework\Attributes\CoversClass;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Input\InputInterface;
@@ -18,7 +18,7 @@ use AlexSkrypnyk\PhpunitHelpers\UnitTestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\ExpectationFailedException;
 
-#[CoversTrait(ApplicationTrait::class)]
+#[CoversClass(ApplicationTrait::class)]
 class ApplicationTraitTest extends UnitTestCase {
 
   use ApplicationTrait;
@@ -194,8 +194,6 @@ class ApplicationTraitTest extends UnitTestCase {
     // Create a test command that throws an exception
     $command = new class() extends Command {
 
-      protected static string $defaultName = 'test:exception';
-
       protected function configure(): void {
         $this->setName('test:exception');
       }
@@ -223,8 +221,6 @@ class ApplicationTraitTest extends UnitTestCase {
     // Create a test command that returns a non-zero exit code
     $command = new class() extends Command {
 
-      protected static string $defaultName = 'test:exit-code';
-
       protected function configure(): void {
         $this->setName('test:exit-code');
       }
@@ -247,8 +243,6 @@ class ApplicationTraitTest extends UnitTestCase {
   public function testApplicationRunWithNonZeroExitCodeAndExpectedFailure(): void {
     // Create a test command that returns a non-zero exit code
     $command = new class() extends Command {
-
-      protected static string $defaultName = 'test:exit-code';
 
       protected function configure(): void {
         $this->setName('test:exit-code');
@@ -274,8 +268,6 @@ class ApplicationTraitTest extends UnitTestCase {
   public function testAssertApplicationFailed(): void {
     // Create a test command that returns a non-zero exit code
     $command = new class() extends Command {
-
-      protected static string $defaultName = 'test:exit-code';
 
       protected function configure(): void {
         $this->setName('test:exit-code');

--- a/tests/Unit/AssertArrayTraitTest.php
+++ b/tests/Unit/AssertArrayTraitTest.php
@@ -6,10 +6,10 @@ namespace AlexSkrypnyk\PhpunitHelpers\Tests\Unit;
 
 use PHPUnit\Framework\AssertionFailedError;
 use AlexSkrypnyk\PhpunitHelpers\Traits\AssertArrayTrait;
-use PHPUnit\Framework\Attributes\CoversTrait;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 
-#[CoversTrait(AssertArrayTrait::class)]
+#[CoversClass(AssertArrayTrait::class)]
 class AssertArrayTraitTest extends TestCase {
 
   use AssertArrayTrait;

--- a/tests/Unit/EnvTraitTest.php
+++ b/tests/Unit/EnvTraitTest.php
@@ -5,10 +5,10 @@ declare(strict_types=1);
 namespace AlexSkrypnyk\PhpunitHelpers\Tests\Unit;
 
 use AlexSkrypnyk\PhpunitHelpers\Traits\EnvTrait;
-use PHPUnit\Framework\Attributes\CoversTrait;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 
-#[CoversTrait(EnvTrait::class)]
+#[CoversClass(EnvTrait::class)]
 class EnvTraitTest extends TestCase {
 
   use EnvTrait;

--- a/tests/Unit/LocationsTraitTest.php
+++ b/tests/Unit/LocationsTraitTest.php
@@ -5,12 +5,12 @@ declare(strict_types=1);
 namespace AlexSkrypnyk\PhpunitHelpers\Tests\Unit;
 
 use AlexSkrypnyk\PhpunitHelpers\Traits\LocationsTrait;
-use PHPUnit\Framework\Attributes\CoversTrait;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Filesystem\Filesystem;
 
-#[CoversTrait(LocationsTrait::class)]
+#[CoversClass(LocationsTrait::class)]
 class LocationsTraitTest extends TestCase {
 
   use LocationsTrait;

--- a/tests/Unit/ProcessTraitTest.php
+++ b/tests/Unit/ProcessTraitTest.php
@@ -4,13 +4,13 @@ declare(strict_types=1);
 
 namespace AlexSkrypnyk\PhpunitHelpers\Tests\Unit;
 
-use PHPUnit\Framework\Attributes\CoversTrait;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\ExpectationFailedException;
 use AlexSkrypnyk\PhpunitHelpers\Traits\ProcessTrait;
 use AlexSkrypnyk\PhpunitHelpers\UnitTestCase;
 use PHPUnit\Framework\Attributes\DataProvider;
 
-#[CoversTrait(ProcessTrait::class)]
+#[CoversClass(ProcessTrait::class)]
 class ProcessTraitTest extends UnitTestCase {
 
   use ProcessTrait;

--- a/tests/Unit/ReflectionTraitTest.php
+++ b/tests/Unit/ReflectionTraitTest.php
@@ -5,10 +5,10 @@ declare(strict_types=1);
 namespace AlexSkrypnyk\PhpunitHelpers\Tests\Unit;
 
 use AlexSkrypnyk\PhpunitHelpers\Traits\ReflectionTrait;
-use PHPUnit\Framework\Attributes\CoversTrait;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 
-#[CoversTrait(ReflectionTrait::class)]
+#[CoversClass(ReflectionTrait::class)]
 class ReflectionTraitTest extends TestCase {
 
   use ReflectionTrait;

--- a/tests/Unit/SerializableClosureTraitTest.php
+++ b/tests/Unit/SerializableClosureTraitTest.php
@@ -6,10 +6,10 @@ namespace AlexSkrypnyk\PhpunitHelpers\Tests\Unit;
 
 use AlexSkrypnyk\PhpunitHelpers\Traits\SerializableClosureTrait;
 use Laravel\SerializableClosure\SerializableClosure;
-use PHPUnit\Framework\Attributes\CoversTrait;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\TestCase;
 
-#[CoversTrait(SerializableClosureTrait::class)]
+#[CoversClass(SerializableClosureTrait::class)]
 class SerializableClosureTraitTest extends TestCase {
 
   use SerializableClosureTrait;

--- a/tests/Unit/TuiTraitTest.php
+++ b/tests/Unit/TuiTraitTest.php
@@ -5,11 +5,11 @@ declare(strict_types=1);
 namespace AlexSkrypnyk\PhpunitHelpers\Tests\Unit;
 
 use AlexSkrypnyk\PhpunitHelpers\Traits\TuiTrait;
-use PHPUnit\Framework\Attributes\CoversTrait;
+use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
-#[CoversTrait(TuiTrait::class)]
+#[CoversClass(TuiTrait::class)]
 class TuiTraitTest extends TestCase {
 
   use TuiTrait;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Expanded PHP test workflow to cover more dependency preferences and enhanced CI artifact naming.
  - Broadened supported Symfony component versions for improved compatibility.
  - Added PHP_CodeSniffer as a development dependency.

- **Tests**
  - Updated test metadata annotations to reflect class coverage instead of trait coverage.
  - Modified test configuration to adjust deprecation display and coverage reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->