### PR TITLE
Fixed `locationsTearDown` not removing directories with limited permissions.

### DIFF
--- a/src/Traits/LocationsTrait.php
+++ b/src/Traits/LocationsTrait.php
@@ -115,7 +115,15 @@ trait LocationsTrait {
    * Will be skipped if the DEBUG environment variable is set.
    */
   public function locationsTearDown(): void {
-    (new Filesystem())->remove(static::$workspace);
+    $fs = new Filesystem();
+    try {
+      $fs->chmod(static::$workspace, 0777, 0000, TRUE);
+    }
+    catch (\Exception $exception) {
+      // Ignore errors if the directory is not writable.
+    }
+
+    $fs->remove(static::$workspace);
   }
 
   /**


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability when removing directories with restricted permissions, ensuring workspace cleanup works even if files or folders are not writable.

- **Tests**
  - Added a test to verify that workspace directories with restricted permissions are properly removed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->