### PR TITLE
Fixed Tui trait not cleaning up the existing value if entry contains a space.

### DIFF
--- a/src/Traits/TuiTrait.php
+++ b/src/Traits/TuiTrait.php
@@ -183,7 +183,7 @@ trait TuiTrait {
       // If an entry has a special key - we consider that any additional
       // functionality like clearing the existing entry or appending an accept
       // key is handled by the consumer.
-      $skip_additional_processing = static::tuiHasKey($entry);
+      $skip_additional_processing = static::tuiHasKey($entry, [self::KEYS['SPACE']]);
 
       // Clear the existing TUI value, if any, one character at a time.
       if (!$skip_additional_processing && $clear_size > 0) {
@@ -251,12 +251,19 @@ trait TuiTrait {
    *
    * @param string $value
    *   The value to check.
+   * @param array $exclude
+   *   An array of keys to exclude from the check.
    *
    * @return bool
    *   TRUE if the value contains a special key, FALSE otherwise.
    */
-  public static function tuiHasKey(string $value): bool {
+  public static function tuiHasKey(string $value, array $exclude = []): bool {
     $flattened_keys = static::tuiKeysFlattened();
+
+    // Exclude specified keys from the check.
+    if (!empty($exclude)) {
+      $flattened_keys = array_diff($flattened_keys, $exclude);
+    }
 
     foreach ($flattened_keys as $key_seq) {
       if (str_contains($value, $key_seq)) {

--- a/tests/Unit/TuiTraitTest.php
+++ b/tests/Unit/TuiTraitTest.php
@@ -199,6 +199,40 @@ class TuiTraitTest extends TestCase {
           self::KEYS['DOWN'], 'n', self::KEYS['ENTER'],
         ],
       ],
+      'string_with_spaces' => [
+        [
+          'answer1' => 'hello world',
+        ],
+        0,
+        NULL,
+        NULL,
+        [
+          'h', 'e', 'l', 'l', 'o', ' ', 'w', 'o', 'r', 'l', 'd', self::KEYS['ENTER'],
+        ],
+      ],
+      'string_with_spaces_an_key' => [
+        [
+          'answer1' => 'hello world',
+        ],
+        0,
+        NULL,
+        NULL,
+        [
+          'h', 'e', 'l', 'l', 'o', self::KEYS['SPACE'], 'w', 'o', 'r', 'l', 'd', self::KEYS['ENTER'],
+        ],
+      ],
+      'string_with_spaces_clear_size' => [
+        [
+          'answer1' => 'hello world',
+        ],
+        2,
+        NULL,
+        NULL,
+        [
+          self::KEYS['BACKSPACE'], self::KEYS['BACKSPACE'],
+          'h', 'e', 'l', 'l', 'o', self::KEYS['SPACE'], 'w', 'o', 'r', 'l', 'd', self::KEYS['ENTER'],
+        ],
+      ],
     ];
   }
 
@@ -219,6 +253,28 @@ class TuiTraitTest extends TestCase {
       'not_a_key' => ['not_a_key', FALSE],
       'key_name_as_string' => ['ENTER', FALSE],
       'empty_string' => ['', FALSE],
+    ];
+  }
+
+  #[DataProvider('dataProviderTuiHasKey')]
+  public function testTuiHasKey(string $value, array $exclude, bool $expected): void {
+    $this->assertEquals($expected, static::tuiHasKey($value, $exclude));
+  }
+
+  public static function dataProviderTuiHasKey(): array {
+    return [
+      'string_with_enter_key' => ['some text' . self::KEYS['ENTER'] . 'more text', [], TRUE],
+      'string_with_space_key' => ['text with' . self::KEYS['SPACE'] . 'space', [], TRUE],
+      'string_with_tab_key' => ['text' . self::KEYS['TAB'] . 'tab', [], TRUE],
+      'string_with_backspace_key' => ['text' . self::KEYS['BACKSPACE'] . 'backspace', [], TRUE],
+      'string_with_arrow_key' => ['text' . self::KEYS['UP'] . 'arrow', [], TRUE],
+      'string_without_keys' => ['plaintext', [], FALSE],
+      'empty_string' => ['', [], FALSE],
+      'string_with_excluded_key' => ['text' . self::KEYS['SPACE'] . 'space', [self::KEYS['SPACE']], FALSE],
+      'string_with_non_excluded_key' => ['text' . self::KEYS['ENTER'] . 'enter', [self::KEYS['SPACE']], TRUE],
+      'string_with_multiple_keys' => ['text' . self::KEYS['ENTER'] . self::KEYS['TAB'] . 'keys', [], TRUE],
+      'string_with_multiple_excluded_keys' => ['text' . self::KEYS['SPACE'] . 'space', [self::KEYS['SPACE'], self::KEYS['TAB']], FALSE],
+      'string_with_mixed_keys_and_exclusions' => ['text' . self::KEYS['ENTER'] . self::KEYS['SPACE'] . 'mixed', [self::KEYS['SPACE']], TRUE],
     ];
   }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of space characters in keystroke sequences, ensuring spaces are processed correctly without being skipped.

* **Tests**
  * Added new test cases to verify correct handling of space characters and special key exclusions.
  * Introduced comprehensive tests for detecting special keys, including scenarios with excluded keys.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->