### PR TITLE
Allow to dim output.

### DIFF
--- a/src/Traits/LoggerTrait.php
+++ b/src/Traits/LoggerTrait.php
@@ -74,8 +74,8 @@ trait LoggerTrait {
 
     // Calculate padding for centering.
     $padding_length = ($total_length - $header_length) / 2;
-    $left_padding = max($min_padding, (int) floor($padding_length));
-    $right_padding = max($min_padding, (int) ceil($padding_length));
+    $left_padding = max($min_padding, (int) ceil($padding_length));
+    $right_padding = max($min_padding, (int) floor($padding_length));
 
     // Create the top delimiter line.
     $top_line = str_repeat($delimiter_char, $left_padding) . $header . str_repeat($delimiter_char, $right_padding);

--- a/src/Traits/ProcessTrait.php
+++ b/src/Traits/ProcessTrait.php
@@ -64,6 +64,13 @@ trait ProcessTrait {
   protected static string $processErrorOutputFooter = '^^^^^^^^^^^ Error output ^^^^^^^^^^^^';
 
   /**
+   * Dim the streaming output.
+   *
+   * This makes the streaming output less prominent in the console.
+   */
+  protected static bool $processStreamingOutputShouldDim = TRUE;
+
+  /**
    * Gets the currently running process.
    *
    * @return \Symfony\Component\Process\Process
@@ -303,9 +310,36 @@ trait ProcessTrait {
           continue;
         }
 
-        fwrite(STDOUT, $prefix . $line . $eol);
+        $line = $prefix . $line . $eol;
+
+        if (static::$processStreamingOutputShouldDim) {
+          $line = static::dim($line);
+        }
+
+        fwrite(STDOUT, $line);
       }
     };
+  }
+
+  /**
+   * Dim the given text for console output.
+   *
+   * @param string $text
+   *   The text to dim.
+   * @param string $eol
+   *   The end-of-line character(s) to use. Default is "\n".
+   *
+   * @return string
+   *   The dimmed text.
+   */
+  protected static function dim(string $text, string $eol = "\n"): string {
+    // Ensure $eol is non-empty for explode().
+    $eol = $eol ?: "\n";
+    $lines = explode($eol, $text);
+    $colored_lines = array_map(function (string $line): string {
+      return sprintf("\033[%sm%s\033[%sm", 2, $line, 22);
+    }, $lines);
+    return implode($eol, $colored_lines);
   }
 
   /**


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Streaming process output can now be dimmed for improved readability (enabled by default).
- Style
  - Log section headers are now more evenly centered, improving visual balance when padding is odd.
- Tests
  - Added unit tests verifying dimmed and non-dimmed streaming output behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->