### PR TITLE
Added process any output assertion methods.

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,6 +289,17 @@ class MyProcessTest extends TestCase {
     $this->assertProcessOutputContainsOrNot(['Hello', '---Error']);
     $this->assertProcessErrorOutputContainsOrNot(['Warning', '---Critical']);
 
+    // Assert that combined output (stdout + stderr) contains string(s).
+    $this->assertProcessAnyOutputContains('Expected in either output');
+    $this->assertProcessAnyOutputContains(['String1', 'String2']); // Can check multiple strings
+
+    // Assert that combined output (stdout + stderr) does not contain string(s).
+    $this->assertProcessAnyOutputNotContains('Should not appear anywhere');
+    $this->assertProcessAnyOutputNotContains(['Unwanted1', 'Unwanted2']); // Can check multiple strings
+
+    // Assert combined output in one call - prefix with '---' for strings that should NOT be present.
+    $this->assertProcessAnyOutputContainsOrNot(['Expected', '---Unwanted']);
+
     // Get debug info about the process (output, error output).
     echo $this->processInfo();
   }

--- a/src/Traits/ProcessTrait.php
+++ b/src/Traits/ProcessTrait.php
@@ -577,6 +577,106 @@ trait ProcessTrait {
   }
 
   /**
+   * Asserts that combined process output contains expected string(s).
+   *
+   * Checks both standard output and error output for the presence of strings.
+   *
+   * @param array|string $expected
+   *   Expected string or array of strings to check for in combined output.
+   */
+  public function assertProcessAnyOutputContains(array|string $expected): void {
+    $this->assertNotNull($this->process, 'Process is not initialized');
+
+    $output = $this->process->getOutput();
+    $output .= $this->process->getErrorOutput();
+
+    $expected = is_array($expected) ? $expected : [$expected];
+
+    foreach ($expected as $value) {
+      if (is_string($value)) {
+        $this->assertStringContainsString($value, $output, sprintf(
+          "Process output does not contain '%s'.%sOutput:%s%s",
+          $value,
+          PHP_EOL,
+          PHP_EOL,
+          $output
+        ));
+      }
+    }
+  }
+
+  /**
+   * Asserts that combined process output does not contain expected string(s).
+   *
+   * Checks both standard output and error output for the absence of strings.
+   *
+   * @param array|string $expected
+   *   String or array of strings that should not be in combined output.
+   */
+  public function assertProcessAnyOutputNotContains(array|string $expected): void {
+    $this->assertNotNull($this->process, 'Process is not initialized');
+
+    $output = $this->process->getOutput();
+    $output .= $this->process->getErrorOutput();
+
+    $expected = is_array($expected) ? $expected : [$expected];
+
+    foreach ($expected as $value) {
+      if (is_string($value)) {
+        $this->assertStringNotContainsString($value, $output, sprintf(
+          "Process output contains '%s' but should not.%sOutput:%s%s",
+          $value,
+          PHP_EOL,
+          PHP_EOL,
+          $output
+        ));
+      }
+    }
+  }
+
+  /**
+   * Asserts combined process output contains or does not contain strings.
+   *
+   * Checks both standard output and error output. For strings that should NOT
+   * be in the output, prefix them with '---'.
+   *
+   * @param string|array $expected
+   *   String or array of strings to check in combined process output.
+   *   Prefix with '---' for strings that should not be present.
+   */
+  public function assertProcessAnyOutputContainsOrNot(string|array $expected): void {
+    $this->assertNotNull($this->process, 'Process is not initialized');
+
+    $output = $this->process->getOutput();
+    $output .= $this->process->getErrorOutput();
+
+    $expected = is_array($expected) ? $expected : [$expected];
+
+    foreach ($expected as $value) {
+      if (str_starts_with($value, '---')) {
+        $value = substr($value, 4);
+
+        $this->assertStringNotContainsString($value, $output, sprintf(
+          "Process output contains '%s' but should not.%sOutput:%s%s",
+          $value,
+          PHP_EOL,
+          PHP_EOL,
+          $output
+        ));
+      }
+      else {
+        $this->assertStringContainsString($value, $output, sprintf(
+          "Process output does not contain '%s'.%sOutput:%s%s",
+          $value,
+          PHP_EOL,
+          PHP_EOL,
+          $output
+        ));
+      }
+    }
+  }
+
+  /**
    * Print the process info.
    *
    * @return string

--- a/tests/Unit/ProcessTraitTest.php
+++ b/tests/Unit/ProcessTraitTest.php
@@ -191,6 +191,46 @@ class ProcessTraitTest extends UnitTestCase {
     ]);
   }
 
+  public function testProcessAnyOutputAssertions(): void {
+    $this->processRun('sh', ['-c', 'echo "Standard Output"; echo "Error Output" 1>&2']);
+
+    $this->assertProcessSuccessful();
+
+    // Test assertProcessAnyOutputContains
+    $this->assertProcessAnyOutputContains('Standard Output');
+    $this->assertProcessAnyOutputContains('Error Output');
+    $this->assertProcessAnyOutputContains(['Standard', 'Error']);
+    $this->assertProcessAnyOutputContains(['Standard Output', 'Error Output']);
+
+    // Test assertProcessAnyOutputNotContains
+    $this->assertProcessAnyOutputNotContains('Nonexistent String');
+    $this->assertProcessAnyOutputNotContains(['NotFound1', 'NotFound2']);
+
+    // Test assertProcessAnyOutputContainsOrNot
+    $this->assertProcessAnyOutputContainsOrNot([
+      'Standard Output',
+      'Error Output',
+      '---Nonexistent String',
+      '---NotFound',
+    ]);
+  }
+
+  public function testProcessAnyOutputAssertionsStandardOutputOnly(): void {
+    $this->processRun('echo', ['Only Standard']);
+
+    $this->assertProcessSuccessful();
+    $this->assertProcessAnyOutputContains('Only Standard');
+    $this->assertProcessAnyOutputNotContains('Error Content');
+  }
+
+  public function testProcessAnyOutputAssertionsErrorOutputOnly(): void {
+    $this->processRun('sh', ['-c', 'echo "Only Error" 1>&2']);
+
+    $this->assertProcessSuccessful();
+    $this->assertProcessAnyOutputContains('Only Error');
+    $this->assertProcessAnyOutputNotContains('Standard Content');
+  }
+
   public function testProcessFailed(): void {
     $command = 'nonexistent-command';
 
@@ -308,6 +348,33 @@ class ProcessTraitTest extends UnitTestCase {
     $this->expectExceptionMessage('Process is not initialized');
 
     $this->assertProcessErrorOutputContainsOrNot('test');
+  }
+
+  public function testAssertProcessAnyOutputContainsWhenNull(): void {
+    $this->process = NULL;
+
+    $this->expectException(ExpectationFailedException::class);
+    $this->expectExceptionMessage('Process is not initialized');
+
+    $this->assertProcessAnyOutputContains('test');
+  }
+
+  public function testAssertProcessAnyOutputNotContainsWhenNull(): void {
+    $this->process = NULL;
+
+    $this->expectException(ExpectationFailedException::class);
+    $this->expectExceptionMessage('Process is not initialized');
+
+    $this->assertProcessAnyOutputNotContains('test');
+  }
+
+  public function testAssertProcessAnyOutputContainsOrNotWhenNull(): void {
+    $this->process = NULL;
+
+    $this->expectException(ExpectationFailedException::class);
+    $this->expectExceptionMessage('Process is not initialized');
+
+    $this->assertProcessAnyOutputContainsOrNot('test');
   }
 
   /**


### PR DESCRIPTION
- Added `assertProcessAnyOutputContains()` to check combined stdout/stderr for presence
- Added `assertProcessAnyOutputNotContains()` to check combined output for absence
- Added `assertProcessAnyOutputContainsOrNot()` with '---' prefix negation support
- All methods accept string or array inputs and follow existing patterns
- Added comprehensive test coverage including edge cases and null validation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced combined-output process assertions that check stdout and stderr together, support multiple strings, and allow mixed presence/absence checks in a single call.

* **Documentation**
  * Updated README with examples showing combined-output assertions, multi-string inputs, and a simple negation syntax for not-present checks.

* **Tests**
  * Added unit tests covering contains, not-contains, mixed contains-or-not scenarios, and error handling when the process is uninitialized.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->