### PR TITLE
Removed `No steps tracked.`.

### DIFF
--- a/src/Traits/LoggerTrait.php
+++ b/src/Traits/LoggerTrait.php
@@ -317,7 +317,6 @@ trait LoggerTrait {
     }
 
     if (empty(static::$loggerSteps)) {
-      static::log('No steps tracked.');
       return;
     }
 

--- a/tests/Unit/LoggerTraitTest.php
+++ b/tests/Unit/LoggerTraitTest.php
@@ -612,11 +612,11 @@ class LoggerTraitTest extends UnitTestCase {
   public function testLogStepSummaryWithNoSteps(): void {
     static::loggerSetVerbose(TRUE);
 
-    // Should display "No steps tracked" message.
+    // Should produce no output when no steps tracked.
     static::logStepSummary();
 
     $output = $this->getCapturedOutput();
-    $this->assertStringContainsString('No steps tracked.', $output);
+    $this->assertEmpty($output);
   }
 
   /**


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Suppressed the unnecessary “No steps tracked.” message when no steps are present, reducing log noise. The summary now remains silent in this scenario without altering other behaviors.

* **Tests**
  * Updated unit tests to expect no output when there are zero tracked steps, aligning test expectations with the new, quieter logging behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->