### PR TITLE
Added support for custom section prefix in logStepStart() and logStepFinish().

### DIFF
--- a/src/Traits/LoggerTrait.php
+++ b/src/Traits/LoggerTrait.php
@@ -41,6 +41,11 @@ trait LoggerTrait {
   protected static array $loggerStepStack = [];
 
   /**
+   * Prefix for identifying step methods.
+   */
+  protected static string $loggerStepMethodPrefix = 'step';
+
+  /**
    * Sets the verbose mode for logging.
    *
    * @param bool $verbose
@@ -224,7 +229,9 @@ trait LoggerTrait {
     // Push current step onto the stack for nested steps.
     static::$loggerStepStack[] = $step;
 
-    static::logSection('STEP START | ' . $step, $message, FALSE, 40);
+    $prefix = str_starts_with($step, static::$loggerStepMethodPrefix) ? sprintf('%s START', strtoupper(static::$loggerStepMethodPrefix)) : 'STEP START';
+    static::logSection($prefix . ' | ' . $step, $message, FALSE, 40);
+
     if (static::$loggerIsVerbose) {
       fwrite(static::getOutputStream(), PHP_EOL);
     }
@@ -241,7 +248,8 @@ trait LoggerTrait {
     $step = $trace[1]['function'] ?? 'unknown';
 
     // Find the most recent unfinished step with matching name.
-    $section_title = 'STEP DONE | ' . $step;
+    $prefix = str_starts_with($step, static::$loggerStepMethodPrefix) ? sprintf('%s DONE', strtoupper(static::$loggerStepMethodPrefix)) : 'STEP DONE';
+    $section_title = $prefix . ' | ' . $step;
     $step_index = NULL;
 
     // Search backwards for the most recent matching step.

--- a/tests/Unit/LoggerTraitTest.php
+++ b/tests/Unit/LoggerTraitTest.php
@@ -328,6 +328,27 @@ class LoggerTraitTest extends UnitTestCase {
   }
 
   /**
+   * Test logStepStart method with custom step method prefix.
+   */
+  public function testLogStepStartWithCustomPrefix(): void {
+    static::loggerSetVerbose(TRUE);
+
+    // Set custom prefix.
+    $original_prefix = static::$loggerStepMethodPrefix;
+    static::$loggerStepMethodPrefix = 'process';
+
+    try {
+      $this->processTest();
+
+      $output = $this->getCapturedOutput();
+      $this->assertStringContainsString('PROCESS START | processTest', $output);
+    } finally {
+      // Restore original prefix.
+      static::$loggerStepMethodPrefix = $original_prefix;
+    }
+  }
+
+  /**
    * Test logStepStart method with verbose mode disabled.
    */
   public function testLogStepStartSilentMode(): void {
@@ -355,6 +376,28 @@ class LoggerTraitTest extends UnitTestCase {
     $this->assertStringContainsString('STEP START | testLogStepFinishVerboseMode', $output);
     $this->assertStringContainsString('STEP DONE | testLogStepFinishVerboseMode | 0s', $output);
     $this->assertStringContainsString('Completed the test step', $output);
+  }
+
+  /**
+   * Test logStepFinish method with custom step method prefix.
+   */
+  public function testLogStepFinishWithCustomPrefix(): void {
+    static::loggerSetVerbose(TRUE);
+
+    // Set custom prefix.
+    $original_prefix = static::$loggerStepMethodPrefix;
+    static::$loggerStepMethodPrefix = 'process';
+
+    try {
+      $this->processFinishTest();
+
+      $output = $this->getCapturedOutput();
+      $this->assertStringContainsString('PROCESS START | processFinishTest', $output);
+      $this->assertStringContainsString('PROCESS DONE | processFinishTest | 0s', $output);
+    } finally {
+      // Restore original prefix.
+      static::$loggerStepMethodPrefix = $original_prefix;
+    }
   }
 
   /**
@@ -1131,6 +1174,22 @@ class LoggerTraitTest extends UnitTestCase {
 
     $this->assertStringContainsString('STEP SUMMARY', $info);
     $this->assertSame("STEP SUMMARY\n", $info);
+  }
+
+  /**
+   * Helper method that starts with 'process' prefix for testing.
+   */
+  private function processTest(): void {
+    static::logStepStart('Testing process prefix');
+    static::logStepFinish('Process prefix test completed');
+  }
+
+  /**
+   * Helper method that starts with 'process' prefix for testing finish.
+   */
+  private function processFinishTest(): void {
+    static::logStepStart('Testing process finish');
+    static::logStepFinish('Process finish test completed');
   }
 
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added support for a configurable step prefix in logging. When a step method name starts with the configured prefix, log headers now display “PREFIX START | <method>” and “PREFIX DONE | <method> | <duration>”. Default behavior remains unchanged for existing users.

- Tests
  - Added unit tests to verify log output with a custom step prefix, covering both start and finish messages and ensuring compatibility with verbose mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->