### PR TITLE
Added optional message parameter to all assertion methods.

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,9 @@ class MyAssertArrayTest extends TestCase {
 
     // Assert that a string is present in an array.
     $this->assertArrayContainsString('test', $array);
+    
+    // Assert with custom failure message.
+    $this->assertArrayContainsString('test', $array, 'Custom message: test string not found');
   }
 }
 ```
@@ -141,6 +144,9 @@ class MyApplicationTest extends TestCase {
     // Assert that the application output contains string(s)
     $this->assertApplicationOutputContains('Expected output');
     $this->assertApplicationOutputContains(['String1', 'String2']); // Can check multiple strings
+    
+    // Assert with custom failure message
+    $this->assertApplicationOutputContains('Expected output', 'Custom message: Expected output not found');
 
     // Assert that the application output does not contain string(s)
     $this->assertApplicationOutputNotContains('Unexpected output');
@@ -296,9 +302,13 @@ class MyProcessTest extends TestCase {
     // Assert that the process output contains string(s).
     $this->assertProcessOutputContains('Hello World');
     $this->assertProcessOutputContains(['Hello', 'World']); // Can check for multiple strings
+    
+    // Assert with custom failure message.
+    $this->assertProcessOutputContains('Hello World', 'Custom message: Expected output not found');
 
     // Assert that the process output does not contain string(s).
     $this->assertProcessOutputNotContains('Error');
+    $this->assertProcessOutputNotContains('Error', 'Custom message: Unexpected error found');
     $this->assertProcessOutputNotContains(['Error1', 'Error2']); // Can check multiple strings
 
     // Assert that the process error output contains string(s).

--- a/src/Traits/ApplicationTrait.php
+++ b/src/Traits/ApplicationTrait.php
@@ -229,10 +229,13 @@ trait ApplicationTrait {
 
   /**
    * Asserts that the application executed successfully.
+   *
+   * @param ?string $message
+   *   Optional failure message.
    */
-  public function assertApplicationSuccessful(): void {
-    $this->assertNotNull($this->applicationTester, 'Application is not initialized');
-    $this->assertSame(0, $this->applicationTester->getStatusCode(), sprintf(
+  public function assertApplicationSuccessful(?string $message = NULL): void {
+    $this->assertNotNull($this->applicationTester, $message ?: 'Application is not initialized');
+    $this->assertSame(0, $this->applicationTester->getStatusCode(), $message ?: sprintf(
       'Application failed with exit code %d: %s%sOutput:%s%s',
       $this->applicationTester->getStatusCode(),
       $this->applicationTester->getErrorOutput(),
@@ -244,10 +247,13 @@ trait ApplicationTrait {
 
   /**
    * Asserts that the application failed to execute.
+   *
+   * @param ?string $message
+   *   Optional failure message.
    */
-  public function assertApplicationFailed(): void {
-    $this->assertNotNull($this->applicationTester, 'Application is not initialized');
-    $this->assertNotSame(0, $this->applicationTester->getStatusCode(), sprintf(
+  public function assertApplicationFailed(?string $message = NULL): void {
+    $this->assertNotNull($this->applicationTester, $message ?: 'Application is not initialized');
+    $this->assertNotSame(0, $this->applicationTester->getStatusCode(), $message ?: sprintf(
       'Application succeeded when failure was expected.%sOutput:%s%s',
       PHP_EOL,
       PHP_EOL,
@@ -260,16 +266,18 @@ trait ApplicationTrait {
    *
    * @param array|string $expected
    *   Expected string or strings to check for in the application output.
+   * @param ?string $message
+   *   Optional failure message.
    */
-  public function assertApplicationOutputContains(array|string $expected): void {
-    $this->assertNotNull($this->applicationTester, 'Application is not initialized');
+  public function assertApplicationOutputContains(array|string $expected, ?string $message = NULL): void {
+    $this->assertNotNull($this->applicationTester, $message ?: 'Application is not initialized');
     $output = $this->applicationTester->getDisplay();
 
     $expected = is_array($expected) ? $expected : [$expected];
 
     foreach ($expected as $value) {
       if (is_string($value)) {
-        $this->assertStringContainsString($value, $output, sprintf(
+        $this->assertStringContainsString($value, $output, $message ?: sprintf(
           "Application output does not contain '%s'.%sOutput:%s%s",
           $value,
           PHP_EOL,
@@ -285,16 +293,18 @@ trait ApplicationTrait {
    *
    * @param array|string $expected
    *   String or array of strings that should not be in the application output.
+   * @param ?string $message
+   *   Optional failure message.
    */
-  public function assertApplicationOutputNotContains(array|string $expected): void {
-    $this->assertNotNull($this->applicationTester, 'Application is not initialized');
+  public function assertApplicationOutputNotContains(array|string $expected, ?string $message = NULL): void {
+    $this->assertNotNull($this->applicationTester, $message ?: 'Application is not initialized');
     $output = $this->applicationTester->getDisplay();
 
     $expected = is_array($expected) ? $expected : [$expected];
 
     foreach ($expected as $value) {
       if (is_string($value)) {
-        $this->assertStringNotContainsString($value, $output, sprintf(
+        $this->assertStringNotContainsString($value, $output, $message ?: sprintf(
           "Application output contains '%s' but should not.%sOutput:%s%s",
           $value,
           PHP_EOL,
@@ -310,16 +320,18 @@ trait ApplicationTrait {
    *
    * @param array|string $expected
    *   Expected string to check for in the application error output.
+   * @param ?string $message
+   *   Optional failure message.
    */
-  public function assertApplicationErrorOutputContains(array|string $expected): void {
-    $this->assertNotNull($this->applicationTester, 'Application is not initialized');
+  public function assertApplicationErrorOutputContains(array|string $expected, ?string $message = NULL): void {
+    $this->assertNotNull($this->applicationTester, $message ?: 'Application is not initialized');
     $output = $this->applicationTester->getErrorOutput();
 
     $expected = is_array($expected) ? $expected : [$expected];
 
     foreach ($expected as $value) {
       if (is_string($value)) {
-        $this->assertStringContainsString($value, $output, sprintf(
+        $this->assertStringContainsString($value, $output, $message ?: sprintf(
           "Application error output does not contain '%s'.%sOutput:%s%s",
           $value,
           PHP_EOL,
@@ -335,16 +347,18 @@ trait ApplicationTrait {
    *
    * @param array|string $expected
    *   String that should not be in the error output.
+   * @param ?string $message
+   *   Optional failure message.
    */
-  public function assertApplicationErrorOutputNotContains(array|string $expected): void {
-    $this->assertNotNull($this->applicationTester, 'Application is not initialized');
+  public function assertApplicationErrorOutputNotContains(array|string $expected, ?string $message = NULL): void {
+    $this->assertNotNull($this->applicationTester, $message ?: 'Application is not initialized');
     $output = $this->applicationTester->getErrorOutput();
 
     $expected = is_array($expected) ? $expected : [$expected];
 
     foreach ($expected as $value) {
       if (is_string($value)) {
-        $this->assertStringNotContainsString($value, $output, sprintf(
+        $this->assertStringNotContainsString($value, $output, $message ?: sprintf(
           "Application error output contains '%s' but should not.%sOutput:%s%s",
           $value,
           PHP_EOL,
@@ -363,9 +377,11 @@ trait ApplicationTrait {
    * @param string|array $expected
    *   String or array of strings to check in the application output.
    *   Prefix with '---' for strings that should not be present.
+   * @param ?string $message
+   *   Optional failure message.
    */
-  public function assertApplicationOutputContainsOrNot(string|array $expected): void {
-    $this->assertNotNull($this->applicationTester, 'Application is not initialized');
+  public function assertApplicationOutputContainsOrNot(string|array $expected, ?string $message = NULL): void {
+    $this->assertNotNull($this->applicationTester, $message ?: 'Application is not initialized');
     $output = $this->applicationTester->getDisplay();
 
     $expected = is_array($expected) ? $expected : [$expected];
@@ -374,7 +390,7 @@ trait ApplicationTrait {
       if (str_starts_with($value, '---')) {
         $value = substr($value, 4);
 
-        $this->assertStringNotContainsString($value, $output, sprintf(
+        $this->assertStringNotContainsString($value, $output, $message ?: sprintf(
           "Application output contains '%s' but should not.%sOutput:%s%s",
           $value,
           PHP_EOL,
@@ -383,7 +399,7 @@ trait ApplicationTrait {
         ));
       }
       else {
-        $this->assertStringContainsString($value, $output, sprintf(
+        $this->assertStringContainsString($value, $output, $message ?: sprintf(
           "Application output does not contain '%s'.%sOutput:%s%s",
           $value,
           PHP_EOL,
@@ -403,9 +419,11 @@ trait ApplicationTrait {
    * @param string|array $expected
    *   String or array of strings to check in the application error output.
    *   Prefix with '---' for strings that should not be present.
+   * @param ?string $message
+   *   Optional failure message.
    */
-  public function assertApplicationErrorOutputContainsOrNot(string|array $expected): void {
-    $this->assertNotNull($this->applicationTester, 'Application is not initialized');
+  public function assertApplicationErrorOutputContainsOrNot(string|array $expected, ?string $message = NULL): void {
+    $this->assertNotNull($this->applicationTester, $message ?: 'Application is not initialized');
     $output = $this->applicationTester->getErrorOutput();
 
     $expected = is_array($expected) ? $expected : [$expected];
@@ -414,7 +432,7 @@ trait ApplicationTrait {
       if (str_starts_with($value, '---')) {
         $value = substr($value, 4);
 
-        $this->assertStringNotContainsString($value, $output, sprintf(
+        $this->assertStringNotContainsString($value, $output, $message ?: sprintf(
           "Application error output contains '%s' but should not.%sOutput:%s%s",
           $value,
           PHP_EOL,
@@ -423,7 +441,7 @@ trait ApplicationTrait {
         ));
       }
       else {
-        $this->assertStringContainsString($value, $output, sprintf(
+        $this->assertStringContainsString($value, $output, $message ?: sprintf(
           "Application error output does not contain '%s'.%sOutput:%s%s",
           $value,
           PHP_EOL,

--- a/src/Traits/AssertArrayTrait.php
+++ b/src/Traits/AssertArrayTrait.php
@@ -20,11 +20,13 @@ trait AssertArrayTrait {
    *   The string to search for.
    * @param array $haystack
    *   The array to search in.
+   * @param ?string $message
+   *   Optional failure message.
    *
    * @throws \PHPUnit\Framework\AssertionFailedError
    *   If the string is not present in the array.
    */
-  public function assertArrayContainsString(string $needle, array $haystack): void {
+  public function assertArrayContainsString(string $needle, array $haystack, ?string $message = NULL): void {
     foreach ($haystack as $hay) {
       if (str_contains((string) $hay, $needle)) {
         $this->addToAssertionCount(1);
@@ -32,7 +34,7 @@ trait AssertArrayTrait {
         return;
       }
     }
-    $this->fail(sprintf('Failed asserting that string "%s" is present in array %s.', $needle, print_r($haystack, TRUE)));
+    $this->fail($message ?: sprintf('Failed asserting that string "%s" is present in array %s.', $needle, print_r($haystack, TRUE)));
   }
 
   /**
@@ -42,17 +44,19 @@ trait AssertArrayTrait {
    *   The string to search for.
    * @param array $haystack
    *   The array to search in.
+   * @param ?string $message
+   *   Optional failure message.
    *
    * @throws \PHPUnit\Framework\AssertionFailedError
    *   If the string is present in the array.
    */
-  public function assertArrayNotContainsString(string $needle, array $haystack): void {
+  public function assertArrayNotContainsString(string $needle, array $haystack, ?string $message = NULL): void {
     foreach ($haystack as $hay) {
       if (is_object($hay)) {
         continue;
       }
       if (str_contains((string) $hay, $needle)) {
-        $this->fail(sprintf('Failed asserting that string "%s" is not present in array %s.', $needle, print_r($haystack, TRUE)));
+        $this->fail($message ?: sprintf('Failed asserting that string "%s" is not present in array %s.', $needle, print_r($haystack, TRUE)));
       }
     }
     $this->addToAssertionCount(1);
@@ -65,11 +69,13 @@ trait AssertArrayTrait {
    *   The main array to search in.
    * @param array $sub_array
    *   The sub-array to search for.
+   * @param ?string $message
+   *   Optional failure message.
    *
    * @throws \PHPUnit\Framework\AssertionFailedError
    *   If any element from the sub-array is not found in the main array.
    */
-  public function assertArrayContainsArray(array $array, array $sub_array): void {
+  public function assertArrayContainsArray(array $array, array $sub_array, ?string $message = NULL): void {
     foreach ($sub_array as $value) {
       if (is_array($value)) {
         $found = FALSE;
@@ -84,7 +90,7 @@ trait AssertArrayTrait {
             if (is_array($item)) {
               // Recursively search within this item.
               try {
-                $this->assertArrayContainsArray($item, [$value]);
+                $this->assertArrayContainsArray($item, [$value], $message);
                 $found = TRUE;
                 break;
               }
@@ -95,10 +101,10 @@ trait AssertArrayTrait {
           }
         }
 
-        $this->assertTrue($found, 'Expected sub-array not found.');
+        $this->assertTrue($found, $message ?: 'Expected sub-array not found.');
       }
       else {
-        $this->assertContains($value, $array, sprintf("Value '%s' not found in array.", $value));
+        $this->assertContains($value, $array, $message ?: sprintf("Value '%s' not found in array.", $value));
       }
     }
   }
@@ -110,16 +116,18 @@ trait AssertArrayTrait {
    *   The main array to search in.
    * @param array $sub_array
    *   The sub-array to search for.
+   * @param ?string $message
+   *   Optional failure message.
    *
    * @throws \PHPUnit\Framework\AssertionFailedError
    *   If any element from the sub-array is found in the main array.
    */
-  public function assertArrayNotContainsArray(array $array, array $sub_array): void {
+  public function assertArrayNotContainsArray(array $array, array $sub_array, ?string $message = NULL): void {
     // Empty subArray against empty array should pass (both are empty)
     // Empty subArray against non-empty array should fail (empty set is subset)
     if (empty($sub_array)) {
       if (!empty($array)) {
-        $this->fail('Empty sub-array is a subset of any non-empty array.');
+        $this->fail($message ?: 'Empty sub-array is a subset of any non-empty array.');
       }
       return;
     }
@@ -129,7 +137,7 @@ trait AssertArrayTrait {
       if (is_array($value)) {
         // Check if value exists as a direct value in array.
         if (in_array($value, $array, TRUE)) {
-          $this->fail('Unexpected sub-array found.');
+          $this->fail($message ?: 'Unexpected sub-array found.');
         }
 
         // Check each element in array recursively.
@@ -137,16 +145,16 @@ trait AssertArrayTrait {
           if (is_array($item)) {
             // Recursively search within this item.
             try {
-              $this->assertArrayNotContainsArray($item, [$value]);
+              $this->assertArrayNotContainsArray($item, [$value], $message);
             }
             catch (\Throwable $e) {
-              $this->fail('Unexpected sub-array found.');
+              $this->fail($message ?: 'Unexpected sub-array found.');
             }
           }
         }
       }
       else {
-        $this->assertNotContains($value, $array, sprintf("Unexpected value '%s' found in array.", $value));
+        $this->assertNotContains($value, $array, $message ?: sprintf("Unexpected value '%s' found in array.", $value));
       }
     }
   }

--- a/src/Traits/ProcessTrait.php
+++ b/src/Traits/ProcessTrait.php
@@ -420,8 +420,10 @@ trait ProcessTrait {
    *
    * @param array|string $expected
    *   Expected string or array of strings to check for in the process output.
+   * @param ?string $message
+   *   Optional failure message.
    */
-  public function assertProcessOutputContains(array|string $expected): void {
+  public function assertProcessOutputContains(array|string $expected, ?string $message = NULL): void {
     $this->assertNotNull($this->process, 'Process is not initialized');
     $output = $this->process->getOutput();
 
@@ -429,7 +431,7 @@ trait ProcessTrait {
 
     foreach ($expected as $value) {
       if (is_string($value)) {
-        $this->assertStringContainsString($value, $output, sprintf(
+        $this->assertStringContainsString($value, $output, $message ?: sprintf(
             "Process output does not contain '%s'.%sOutput:%s%s",
             $value,
             PHP_EOL,
@@ -445,8 +447,10 @@ trait ProcessTrait {
    *
    * @param array|string $expected
    *   String or array of strings that should not be in the process output.
+   * @param ?string $message
+   *   Optional failure message.
    */
-  public function assertProcessOutputNotContains(array|string $expected): void {
+  public function assertProcessOutputNotContains(array|string $expected, ?string $message = NULL): void {
     $this->assertNotNull($this->process, 'Process is not initialized');
     $output = $this->process->getOutput();
 
@@ -454,7 +458,7 @@ trait ProcessTrait {
 
     foreach ($expected as $value) {
       if (is_string($value)) {
-        $this->assertStringNotContainsString($value, $output, sprintf(
+        $this->assertStringNotContainsString($value, $output, $message ?: sprintf(
             "Process output contains '%s' but should not.%sOutput:%s%s",
             $value,
             PHP_EOL,
@@ -470,8 +474,10 @@ trait ProcessTrait {
    *
    * @param string $expected
    *   Expected string to check for in the process error output.
+   * @param ?string $message
+   *   Optional failure message.
    */
-  public function assertProcessErrorOutputContains(array|string $expected): void {
+  public function assertProcessErrorOutputContains(array|string $expected, ?string $message = NULL): void {
     $this->assertNotNull($this->process, 'Process is not initialized');
     $output = $this->process->getErrorOutput();
 
@@ -479,7 +485,7 @@ trait ProcessTrait {
 
     foreach ($expected as $value) {
       if (is_string($value)) {
-        $this->assertStringContainsString($value, $output, sprintf(
+        $this->assertStringContainsString($value, $output, $message ?: sprintf(
             "Process error output does not contain '%s'.%sOutput:%s%s",
             $value,
             PHP_EOL,
@@ -495,8 +501,10 @@ trait ProcessTrait {
    *
    * @param string $expected
    *   String that should not be in the process error output.
+   * @param ?string $message
+   *   Optional failure message.
    */
-  public function assertProcessErrorOutputNotContains(array|string $expected): void {
+  public function assertProcessErrorOutputNotContains(array|string $expected, ?string $message = NULL): void {
     $this->assertNotNull($this->process, 'Process is not initialized');
     $output = $this->process->getErrorOutput();
 
@@ -504,7 +512,7 @@ trait ProcessTrait {
 
     foreach ($expected as $value) {
       if (is_string($value)) {
-        $this->assertStringNotContainsString($value, $output, sprintf(
+        $this->assertStringNotContainsString($value, $output, $message ?: sprintf(
             "Process error output contains '%s' but should not.%sOutput:%s%s",
             $value,
             PHP_EOL,
@@ -535,11 +543,13 @@ trait ProcessTrait {
    *   '- ' prefix for exact match absent,
    *   '! ' prefix for substring absent.
    *   If any string has a prefix, ALL strings must have prefixes.
+   * @param ?string $message
+   *   Optional failure message.
    *
    * @throws \RuntimeException
    *   When prefix usage is inconsistent (some have prefixes, others don't).
    */
-  public function assertProcessOutputContainsOrNot(string|array $expected): void {
+  public function assertProcessOutputContainsOrNot(string|array $expected, ?string $message = NULL): void {
     $this->assertNotNull($this->process, 'Process is not initialized');
 
     $output = $this->process->getOutput();
@@ -547,10 +557,10 @@ trait ProcessTrait {
     $this->assertStringContainsOrNot(
       $output,
       $expected,
-      "Process output exact match failed for '%s'" . $this->assertionSuffix(),
-      "Process output does not contain '%s'" . $this->assertionSuffix(),
-      "Process output should not exactly match '%s'" . $this->assertionSuffix(),
-      "Process output contains '%s' but should not" . $this->assertionSuffix()
+      $message ?: "Process output exact match failed for '%s'" . $this->assertionSuffix(),
+      $message ?: "Process output does not contain '%s'" . $this->assertionSuffix(),
+      $message ?: "Process output should not exactly match '%s'" . $this->assertionSuffix(),
+      $message ?: "Process output contains '%s' but should not" . $this->assertionSuffix()
     );
   }
 
@@ -574,11 +584,13 @@ trait ProcessTrait {
    *   '- ' prefix for exact match absent,
    *   '! ' prefix for substring absent.
    *   If any string has a prefix, ALL strings must have prefixes.
+   * @param ?string $message
+   *   Optional failure message.
    *
    * @throws \RuntimeException
    *   When prefix usage is inconsistent (some have prefixes, others don't).
    */
-  public function assertProcessErrorOutputContainsOrNot(string|array $expected): void {
+  public function assertProcessErrorOutputContainsOrNot(string|array $expected, ?string $message = NULL): void {
     $this->assertNotNull($this->process, 'Process is not initialized');
 
     $output = $this->process->getErrorOutput();
@@ -586,10 +598,10 @@ trait ProcessTrait {
     $this->assertStringContainsOrNot(
       $output,
       $expected,
-      "Process error output exact match failed for '%s'" . $this->assertionSuffix(),
-      "Process error output does not contain '%s'" . $this->assertionSuffix(),
-      "Process error output should not exactly match '%s'" . $this->assertionSuffix(),
-      "Process error output contains '%s' but should not" . $this->assertionSuffix()
+      $message ?: "Process error output exact match failed for '%s'" . $this->assertionSuffix(),
+      $message ?: "Process error output does not contain '%s'" . $this->assertionSuffix(),
+      $message ?: "Process error output should not exactly match '%s'" . $this->assertionSuffix(),
+      $message ?: "Process error output contains '%s' but should not" . $this->assertionSuffix()
     );
   }
 
@@ -600,8 +612,10 @@ trait ProcessTrait {
    *
    * @param array|string $expected
    *   Expected string or array of strings to check for in combined output.
+   * @param ?string $message
+   *   Optional failure message.
    */
-  public function assertProcessAnyOutputContains(array|string $expected): void {
+  public function assertProcessAnyOutputContains(array|string $expected, ?string $message = NULL): void {
     $this->assertNotNull($this->process, 'Process is not initialized');
 
     $output = $this->process->getOutput();
@@ -611,13 +625,13 @@ trait ProcessTrait {
 
     foreach ($expected as $value) {
       if (is_string($value)) {
-        $this->assertStringContainsString($value, $output, sprintf(
-          "Process output does not contain '%s'.%sOutput:%s%s",
-          $value,
-          PHP_EOL,
-          PHP_EOL,
-          $output
-        ) . $this->assertionSuffix());
+        $this->assertStringContainsString($value, $output, $message ?: sprintf(
+            "Process output does not contain '%s'.%sOutput:%s%s",
+            $value,
+            PHP_EOL,
+            PHP_EOL,
+            $output
+          ) . $this->assertionSuffix());
       }
     }
   }
@@ -629,8 +643,10 @@ trait ProcessTrait {
    *
    * @param array|string $expected
    *   String or array of strings that should not be in combined output.
+   * @param ?string $message
+   *   Optional failure message.
    */
-  public function assertProcessAnyOutputNotContains(array|string $expected): void {
+  public function assertProcessAnyOutputNotContains(array|string $expected, ?string $message = NULL): void {
     $this->assertNotNull($this->process, 'Process is not initialized');
 
     $output = $this->process->getOutput();
@@ -640,13 +656,13 @@ trait ProcessTrait {
 
     foreach ($expected as $value) {
       if (is_string($value)) {
-        $this->assertStringNotContainsString($value, $output, sprintf(
-          "Process output contains '%s' but should not.%sOutput:%s%s",
-          $value,
-          PHP_EOL,
-          PHP_EOL,
-          $output
-        ) . $this->assertionSuffix());
+        $this->assertStringNotContainsString($value, $output, $message ?: sprintf(
+            "Process output contains '%s' but should not.%sOutput:%s%s",
+            $value,
+            PHP_EOL,
+            PHP_EOL,
+            $output
+          ) . $this->assertionSuffix());
       }
     }
   }
@@ -672,11 +688,13 @@ trait ProcessTrait {
    *   '- ' prefix for exact match absent,
    *   '! ' prefix for substring absent.
    *   If any string has a prefix, ALL strings must have prefixes.
+   * @param ?string $message
+   *   Optional failure message.
    *
    * @throws \RuntimeException
    *   When prefix usage is inconsistent (some have prefixes, others don't).
    */
-  public function assertProcessAnyOutputContainsOrNot(string|array $expected): void {
+  public function assertProcessAnyOutputContainsOrNot(string|array $expected, ?string $message = NULL): void {
     $this->assertNotNull($this->process, 'Process is not initialized');
 
     $output = $this->process->getOutput();
@@ -685,10 +703,10 @@ trait ProcessTrait {
     $this->assertStringContainsOrNot(
       $output,
       $expected,
-      "Process output exact match failed for '%s'" . $this->assertionSuffix(),
-      "Process output does not contain '%s'" . $this->assertionSuffix(),
-      "Process output should not exactly match '%s'" . $this->assertionSuffix(),
-      "Process output contains '%s' but should not" . $this->assertionSuffix()
+      $message ?: "Process output exact match failed for '%s'" . $this->assertionSuffix(),
+      $message ?: "Process output does not contain '%s'" . $this->assertionSuffix(),
+      $message ?: "Process output should not exactly match '%s'" . $this->assertionSuffix(),
+      $message ?: "Process output contains '%s' but should not" . $this->assertionSuffix()
     );
   }
 

--- a/tests/Unit/AssertArrayTraitTest.php
+++ b/tests/Unit/AssertArrayTraitTest.php
@@ -479,4 +479,16 @@ class AssertArrayTraitTest extends TestCase {
     ];
   }
 
+  /**
+   * Test custom failure messages work correctly.
+   */
+  public function testCustomFailureMessages(): void {
+    $custom_message = 'This is a custom failure message';
+
+    $this->expectException(AssertionFailedError::class);
+    $this->expectExceptionMessage($custom_message);
+
+    $this->assertArrayContainsString('nonexistent', ['test', 'array'], $custom_message);
+  }
+
 }

--- a/tests/Unit/ProcessTraitTest.php
+++ b/tests/Unit/ProcessTraitTest.php
@@ -1456,4 +1456,18 @@ $test->processRun("echo", ["test output"]);
     static::$processStreamingOutputShouldDim = TRUE;
   }
 
+  /**
+   * Test custom failure messages work correctly.
+   */
+  public function testCustomFailureMessages(): void {
+    $this->processRun('echo', ['test output']);
+
+    $custom_message = 'This is a custom failure message';
+
+    $this->expectException(AssertionFailedError::class);
+    $this->expectExceptionMessage($custom_message);
+
+    $this->assertProcessOutputContains('nonexistent', $custom_message);
+  }
+
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Assertion helpers now accept optional custom failure messages across application, process, and array checks (contains/not-contains, output/error output, any-output variants). Backward-compatible; default messages remain when none is provided.
- Documentation
  - README updated with examples showing how to supply custom failure messages.
- Tests
  - Added unit tests verifying custom failure messages are surfaced on assertion failures for array and process helpers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->