### PR TITLE
Added `envUnsetMultiple()` method.

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,9 @@ class MyEnvTest extends TestCase {
     // Unset an environment variable.
     self::envUnset('MY_VAR');
 
+    // Unset multiple environment variables.
+    self::envUnsetMultiple(['VAR1', 'VAR2']);
+
     // Unset all environment variables with a specific prefix.
     self::envUnsetPrefix('MY_');
 

--- a/src/Traits/EnvTrait.php
+++ b/src/Traits/EnvTrait.php
@@ -57,6 +57,18 @@ trait EnvTrait {
   }
 
   /**
+   * Unset multiple environment variables.
+   *
+   * @param array $names
+   *   An array of environment variable names to unset.
+   */
+  public static function envUnsetMultiple(array $names): void {
+    foreach ($names as $name) {
+      static::envUnset($name);
+    }
+  }
+
+  /**
    * Unset an environment variable by prefix.
    *
    * @param string $prefix

--- a/tests/Unit/EnvTraitTest.php
+++ b/tests/Unit/EnvTraitTest.php
@@ -62,6 +62,28 @@ class EnvTraitTest extends TestCase {
     $this->assertTrue($this->envIsUnset($name));
   }
 
+  public function testEnvUnsetMultiple(): void {
+    $vars = [
+      'TEST_ENV_VAR1' => 'value1',
+      'TEST_ENV_VAR2' => 'value2',
+      'TEST_ENV_VAR3' => 'value3',
+      'TEST_ENV_VAR4' => 'value4',
+    ];
+
+    $this->envSetMultiple($vars);
+
+    foreach (array_keys($vars) as $name) {
+      $this->assertTrue($this->envIsSet($name));
+    }
+
+    $this->envUnsetMultiple(['TEST_ENV_VAR1', 'TEST_ENV_VAR2', 'TEST_ENV_VAR3']);
+
+    $this->assertFalse($this->envIsSet('TEST_ENV_VAR1'));
+    $this->assertFalse($this->envIsSet('TEST_ENV_VAR2'));
+    $this->assertFalse($this->envIsSet('TEST_ENV_VAR3'));
+    $this->assertTrue($this->envIsSet('TEST_ENV_VAR4'));
+  }
+
   public function testEnvUnsetPrefix(): void {
     $vars = [
       'TEST_PREFIX_VAR1' => 'value1',


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added batch unsetting capability to remove multiple environment variables in a single operation.

* **Documentation**
  * Updated README with a usage example showing batch unsetting alongside single-variable operations.

* **Tests**
  * Added unit test covering setting multiple vars and verifying partial batch unsetting behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->