### PR TITLE
Converged naming, API shape and comment register across the codebase.

### DIFF
--- a/src/Traits/ApplicationTrait.php
+++ b/src/Traits/ApplicationTrait.php
@@ -49,6 +49,9 @@ trait ApplicationTrait {
    *
    * @return \Symfony\Component\Console\Application
    *   The application instance.
+   *
+   * @throws \RuntimeException
+   *   If the application is not initialized.
    */
   public function applicationGet(): Application {
     if ($this->application === NULL) {
@@ -91,6 +94,9 @@ trait ApplicationTrait {
    *
    * @return \Symfony\Component\Console\Tester\ApplicationTester
    *   The initialized application tester.
+   *
+   * @throws \InvalidArgumentException
+   *   When the loader file is missing or does not return an application.
    */
   public function applicationInitFromLoader(string $loader_path): ApplicationTester {
     if (!file_exists($loader_path)) {
@@ -134,6 +140,9 @@ trait ApplicationTrait {
    *
    * @return \Symfony\Component\Console\Tester\ApplicationTester
    *   The initialized application tester.
+   *
+   * @throws \InvalidArgumentException
+   *   When the provided object or class is not a command.
    */
   public function applicationInitFromCommand(string|object $object_or_class, bool $is_single_command = TRUE): ApplicationTester {
     $this->application = new Application();
@@ -186,6 +195,11 @@ trait ApplicationTrait {
    *
    * @return string
    *   Application output.
+   *
+   * @throws \RuntimeException
+   *   When the application is not initialized.
+   * @throws \PHPUnit\Framework\AssertionFailedError
+   *   When the application outcome does not match the expectation.
    */
   public function applicationRun(array $input = [], array $options = [], bool $expect_fail = FALSE): string {
     if ($this->applicationTester === NULL) {

--- a/src/Traits/ApplicationTrait.php
+++ b/src/Traits/ApplicationTrait.php
@@ -103,11 +103,15 @@ trait ApplicationTrait {
       throw new \InvalidArgumentException(sprintf('Loader file not found: %s', $loader_path));
     }
 
-    $this->application = require $loader_path;
+    // Validate before assigning: the property is typed, so assigning a wrong
+    // type raises a TypeError before this guard can run.
+    $application = require $loader_path;
 
-    if (!$this->application instanceof Application) {
+    if (!$application instanceof Application) {
       throw new \InvalidArgumentException('Loader must return an instance of Application');
     }
+
+    $this->application = $application;
 
     $this->application->setAutoExit(FALSE);
     $this->application->setCatchExceptions(TRUE);

--- a/src/Traits/ApplicationTrait.php
+++ b/src/Traits/ApplicationTrait.php
@@ -54,7 +54,7 @@ trait ApplicationTrait {
    *   If the application is not initialized.
    */
   public function applicationGet(): Application {
-    if ($this->application === NULL) {
+    if (!$this->application instanceof Application) {
       throw new \RuntimeException('Application is not initialized. Call applicationInit* first.');
     }
     return $this->application;
@@ -70,7 +70,7 @@ trait ApplicationTrait {
    *   If the application tester is not initialized.
    */
   public function applicationGetTester(): ApplicationTester {
-    if ($this->applicationTester === NULL) {
+    if (!$this->applicationTester instanceof ApplicationTester) {
       throw new \RuntimeException('Application tester is not initialized. Call applicationInit* first.');
     }
     return $this->applicationTester;
@@ -202,7 +202,7 @@ trait ApplicationTrait {
    *   When the application outcome does not match the expectation.
    */
   public function applicationRun(array $input = [], array $options = [], bool $expect_fail = FALSE): string {
-    if ($this->applicationTester === NULL) {
+    if (!$this->applicationTester instanceof ApplicationTester) {
       throw new \RuntimeException('Application is not initialized. Call applicationInit* first.');
     }
 
@@ -533,9 +533,10 @@ trait ApplicationTrait {
    *   The application info.
    */
   public function applicationInfo(): string {
-    if ($this->applicationTester === NULL) {
+    if (!$this->applicationTester instanceof ApplicationTester) {
       return 'APPLICATION: Not initialized' . PHP_EOL;
     }
+    $lines = [];
     $lines[] = 'APPLICATION';
     $lines[] = 'Output:';
     $output = $this->applicationTester->getDisplay();

--- a/src/Traits/ApplicationTrait.php
+++ b/src/Traits/ApplicationTrait.php
@@ -135,7 +135,7 @@ trait ApplicationTrait {
    * @return \Symfony\Component\Console\Tester\ApplicationTester
    *   The initialized application tester.
    */
-  public function applicationInitFromCommand(string | object $object_or_class, bool $is_single_command = TRUE): ApplicationTester {
+  public function applicationInitFromCommand(string|object $object_or_class, bool $is_single_command = TRUE): ApplicationTester {
     $this->application = new Application();
 
     $instance = is_object($object_or_class) ? $object_or_class : new $object_or_class();
@@ -281,7 +281,7 @@ trait ApplicationTrait {
    * @param ?string $message
    *   Optional failure message.
    */
-  public function assertApplicationOutputContains(array | string $expected, ?string $message = NULL): void {
+  public function assertApplicationOutputContains(array|string $expected, ?string $message = NULL): void {
     $this->assertNotNull($this->applicationTester, $message ?: 'Application is not initialized');
     $output = $this->applicationTester->getDisplay();
 
@@ -308,7 +308,7 @@ trait ApplicationTrait {
    * @param ?string $message
    *   Optional failure message.
    */
-  public function assertApplicationOutputNotContains(array | string $expected, ?string $message = NULL): void {
+  public function assertApplicationOutputNotContains(array|string $expected, ?string $message = NULL): void {
     $this->assertNotNull($this->applicationTester, $message ?: 'Application is not initialized');
     $output = $this->applicationTester->getDisplay();
 
@@ -335,7 +335,7 @@ trait ApplicationTrait {
    * @param ?string $message
    *   Optional failure message.
    */
-  public function assertApplicationErrorOutputContains(array | string $expected, ?string $message = NULL): void {
+  public function assertApplicationErrorOutputContains(array|string $expected, ?string $message = NULL): void {
     $this->assertNotNull($this->applicationTester, $message ?: 'Application is not initialized');
     $output = $this->applicationTester->getErrorOutput();
 
@@ -362,7 +362,7 @@ trait ApplicationTrait {
    * @param ?string $message
    *   Optional failure message.
    */
-  public function assertApplicationErrorOutputNotContains(array | string $expected, ?string $message = NULL): void {
+  public function assertApplicationErrorOutputNotContains(array|string $expected, ?string $message = NULL): void {
     $this->assertNotNull($this->applicationTester, $message ?: 'Application is not initialized');
     $output = $this->applicationTester->getErrorOutput();
 
@@ -394,7 +394,7 @@ trait ApplicationTrait {
    * - Shortcut mode: No prefixes, all strings treated as substring present
    * - Mixed mode: If any string has a prefix, ALL strings must have prefixes
    *
-   * @param string|array $expected
+   * @param array|string $expected
    *   String or array of strings to check in the application output.
    *   Use '+ ' prefix for exact match present,
    *   '* ' prefix for substring present,
@@ -407,7 +407,7 @@ trait ApplicationTrait {
    * @throws \RuntimeException
    *   When prefix usage is inconsistent (some have prefixes, others don't).
    */
-  public function assertApplicationOutputContainsOrNot(string|array $expected, ?string $message = NULL): void {
+  public function assertApplicationOutputContainsOrNot(array|string $expected, ?string $message = NULL): void {
     $this->assertNotNull($this->applicationTester, $message ?: 'Application is not initialized');
 
     $output = $this->applicationTester->getDisplay();
@@ -437,7 +437,7 @@ trait ApplicationTrait {
    * - Shortcut mode: No prefixes, all strings treated as substring present
    * - Mixed mode: If any string has a prefix, ALL strings must have prefixes
    *
-   * @param string|array $expected
+   * @param array|string $expected
    *   String or array of strings to check in the application error output.
    *   Use '+ ' prefix for exact match present,
    *   '* ' prefix for substring present,
@@ -450,7 +450,7 @@ trait ApplicationTrait {
    * @throws \RuntimeException
    *   When prefix usage is inconsistent (some have prefixes, others don't).
    */
-  public function assertApplicationErrorOutputContainsOrNot(string|array $expected, ?string $message = NULL): void {
+  public function assertApplicationErrorOutputContainsOrNot(array|string $expected, ?string $message = NULL): void {
     $this->assertNotNull($this->applicationTester, $message ?: 'Application is not initialized');
 
     $output = $this->applicationTester->getErrorOutput();
@@ -481,7 +481,7 @@ trait ApplicationTrait {
    * - Shortcut mode: No prefixes, all strings treated as substring present
    * - Mixed mode: If any string has a prefix, ALL strings must have prefixes
    *
-   * @param string|array $expected
+   * @param array|string $expected
    *   String or array of strings to check in combined process output.
    *   Use '+ ' prefix for exact match present,
    *   '* ' prefix for substring present,
@@ -494,7 +494,7 @@ trait ApplicationTrait {
    * @throws \RuntimeException
    *   When prefix usage is inconsistent (some have prefixes, others don't).
    */
-  public function assertApplicationAnyOutputContainsOrNot(string|array $expected, ?string $message = NULL): void {
+  public function assertApplicationAnyOutputContainsOrNot(array|string $expected, ?string $message = NULL): void {
     $this->assertNotNull($this->applicationTester, $message ?: 'Application is not initialized');
 
     $output = $this->applicationTester->getDisplay();

--- a/src/Traits/ApplicationTrait.php
+++ b/src/Traits/ApplicationTrait.php
@@ -112,12 +112,10 @@ trait ApplicationTrait {
     $this->application->setAutoExit(FALSE);
     $this->application->setCatchExceptions(TRUE);
 
-    // Change the working directory if specified.
     if ($this->applicationCwd !== NULL) {
       $original_cwd = getcwd();
       if ($original_cwd !== FALSE) {
         chdir($this->applicationCwd);
-        // Register shutdown function to restore original working directory.
         // @codeCoverageIgnoreStart
         register_shutdown_function(function () use ($original_cwd): void {
           chdir($original_cwd);
@@ -165,12 +163,10 @@ trait ApplicationTrait {
     $this->application->setAutoExit(FALSE);
     $this->application->setCatchExceptions(TRUE);
 
-    // Change the working directory if specified.
     if ($this->applicationCwd !== NULL) {
       $original_cwd = getcwd();
       if ($original_cwd !== FALSE) {
         chdir($this->applicationCwd);
-        // Register shutdown function to restore original working directory.
         // @codeCoverageIgnoreStart
         register_shutdown_function(function () use ($original_cwd): void {
           chdir($original_cwd);
@@ -224,7 +220,7 @@ trait ApplicationTrait {
         throw new \Exception(sprintf("Application exited with non-zero code.\nThe output was:\n%s\nThe error output was:\n%s", $this->applicationTester->getDisplay(), $this->applicationTester->getErrorOutput()));
       }
 
-      // Expected to fail, but succeeded (was called with expect_fail = TRUE).
+      // Expected to fail, but succeeded.
       if ($expect_fail) {
         throw new AssertionFailedError(sprintf("Application exited successfully but should not.\nThe output was:\n%s\nThe error output was:\n%s", $this->applicationTester->getDisplay(), $this->applicationTester->getErrorOutput()));
       }
@@ -238,16 +234,15 @@ trait ApplicationTrait {
       $output = $exception->getMessage();
     }
     catch (\Exception $exception) {
-      // Caught exception, check if we expected failure.
       if (!$expect_fail) {
-        // Expecting success (was called with expect_fail = FALSE).
+        // Expected to succeed, but failed.
         throw new AssertionFailedError('Application exited with an error:' . PHP_EOL . $exception->getMessage(), $exception->getCode(), $exception);
       }
       // Expected to fail, so capture the output.
       $output = $exception->getMessage();
     }
 
-    // Append error output. Internally, error output is captured separately.
+    // Error output is captured separately, so append it to the output.
     $output .= $this->applicationTester->getErrorOutput();
 
     return $output;

--- a/src/Traits/AssertArrayTrait.php
+++ b/src/Traits/AssertArrayTrait.php
@@ -5,8 +5,6 @@ declare(strict_types=1);
 namespace AlexSkrypnyk\PhpunitHelpers\Traits;
 
 /**
- * Trait AssertTrait.
- *
  * Provides custom assertions.
  *
  * @mixin \PHPUnit\Framework\TestCase
@@ -80,15 +78,12 @@ trait AssertArrayTrait {
       if (is_array($value)) {
         $found = FALSE;
 
-        // Check if value exists as a direct value in array.
         if (in_array($value, $array, TRUE)) {
           $found = TRUE;
         }
         else {
-          // Check each element in array recursively.
           foreach ($array as $item) {
             if (is_array($item)) {
-              // Recursively search within this item.
               try {
                 $this->assertArrayContainsArray($item, [$value], $message);
                 $found = TRUE;
@@ -123,8 +118,8 @@ trait AssertArrayTrait {
    *   If any element from the sub-array is found in the main array.
    */
   public function assertArrayNotContainsArray(array $array, array $sub_array, ?string $message = NULL): void {
-    // Empty subArray against empty array should pass (both are empty)
-    // Empty subArray against non-empty array should fail (empty set is subset)
+    // An empty $sub_array passes against an empty $array (both are empty)
+    // and fails against a non-empty one (the empty set is a subset).
     if (empty($sub_array)) {
       if (!empty($array)) {
         $this->fail($message ?: 'Empty sub-array is a subset of any non-empty array.');
@@ -132,18 +127,14 @@ trait AssertArrayTrait {
       return;
     }
 
-    // Check that NONE of the elements in subArray are found in array.
     foreach ($sub_array as $value) {
       if (is_array($value)) {
-        // Check if value exists as a direct value in array.
         if (in_array($value, $array, TRUE)) {
           $this->fail($message ?: 'Unexpected sub-array found.');
         }
 
-        // Check each element in array recursively.
         foreach ($array as $item) {
           if (is_array($item)) {
-            // Recursively search within this item.
             try {
               $this->assertArrayNotContainsArray($item, [$value], $message);
             }

--- a/src/Traits/EnvTrait.php
+++ b/src/Traits/EnvTrait.php
@@ -110,6 +110,9 @@ trait EnvTrait {
 
   /**
    * Check if an environment variable is not set.
+   *
+   * @param string $name
+   *   The name of the environment variable.
    */
   public static function envIsUnset(string $name): bool {
     return getenv($name) === FALSE;

--- a/src/Traits/EnvTrait.php
+++ b/src/Traits/EnvTrait.php
@@ -5,9 +5,7 @@ declare(strict_types=1);
 namespace AlexSkrypnyk\PhpunitHelpers\Traits;
 
 /**
- * Trait EnvTrait.
- *
- * Trait for managing environment variables.
+ * Manages environment variables.
  *
  * @mixin \PHPUnit\Framework\TestCase
  */

--- a/src/Traits/EnvTrait.php
+++ b/src/Traits/EnvTrait.php
@@ -93,6 +93,9 @@ trait EnvTrait {
    *
    * @param string $name
    *   The name of the environment variable.
+   *
+   * @return mixed
+   *   The value of the environment variable, or FALSE if it is not set.
    */
   public static function envGet(string $name): mixed {
     return getenv($name);
@@ -103,6 +106,9 @@ trait EnvTrait {
    *
    * @param string $name
    *   The name of the environment variable.
+   *
+   * @return bool
+   *   TRUE if the environment variable is set, FALSE otherwise.
    */
   public static function envIsSet(string $name): bool {
     return getenv($name) !== FALSE;
@@ -113,6 +119,9 @@ trait EnvTrait {
    *
    * @param string $name
    *   The name of the environment variable.
+   *
+   * @return bool
+   *   TRUE if the environment variable is not set, FALSE otherwise.
    */
   public static function envIsUnset(string $name): bool {
     return getenv($name) === FALSE;

--- a/src/Traits/LocationsTrait.php
+++ b/src/Traits/LocationsTrait.php
@@ -139,6 +139,9 @@ trait LocationsTrait {
    *
    * @return string
    *   The fixtures directory path.
+   *
+   * @throws \RuntimeException
+   *   When the fixtures directory does not exist.
    */
   public function locationsFixtureDir(?string $name = NULL): string {
     $fixtures_dir = static::$root . DIRECTORY_SEPARATOR . static::locationsFixturesDir();
@@ -282,6 +285,9 @@ trait LocationsTrait {
    *
    * @return array<int, string>
    *   The list of created file paths.
+   *
+   * @throws \RuntimeException
+   *   When the base directory does not exist.
    */
   public static function locationsCopyFilesToSut(array $files, ?string $basedir = NULL, bool $append_rand = TRUE): array {
     $basedir = $basedir ?: getcwd();

--- a/src/Traits/LocationsTrait.php
+++ b/src/Traits/LocationsTrait.php
@@ -44,7 +44,7 @@ trait LocationsTrait {
   protected static ?string $fixtures = NULL;
 
   /**
-   * Main workspace directory where the rest of the directories located.
+   * Main workspace directory where the rest of the directories are located.
    *
    * The "workspace" in this context is a place to store assets produced by a
    * single test run.
@@ -151,12 +151,10 @@ trait LocationsTrait {
 
     $path = static::locationsRealpath($fixtures_dir);
 
-    // Set the fixtures directory based on the passed name.
     if ($name) {
       $path .= DIRECTORY_SEPARATOR . $name;
     }
     else {
-      // Set the fixtures directory based on the test name.
       $fixture_dir = $this->name();
       $fixture_dir = str_contains($fixture_dir, '::') ? explode('::', $fixture_dir)[1] : $fixture_dir;
       $fixture_dir = strtolower((string) preg_replace('/(?<!^)[A-Z]/', '_$0', $fixture_dir));
@@ -164,15 +162,12 @@ trait LocationsTrait {
       $path .= DIRECTORY_SEPARATOR . $fixture_dir;
     }
 
-    // Further adjust the fixtures directory name if the test uses a
-    // data provider with named data sets.
     $data_name = $this->dataName();
     if (!empty($data_name) && !is_numeric($data_name)) {
       if ($data_name === static::BASELINE_DATASET) {
         $path_suffix = static::BASELINE_DIR;
       }
       else {
-        // Convert the data name to a snake case string.
         $path_suffix = strtolower(str_replace(['-', ' '], '_', (string) preg_replace('/[^a-zA-Z0-9_\- ]/', '', $data_name)));
       }
       $path .= DIRECTORY_SEPARATOR . $path_suffix;

--- a/src/Traits/LocationsTrait.php
+++ b/src/Traits/LocationsTrait.php
@@ -188,6 +188,7 @@ trait LocationsTrait {
    *   The locations' info.
    */
   public static function locationsInfo(): string {
+    $lines = [];
     $lines[] = 'LOCATIONS';
     $lines[] = '---------';
     $lines[] = 'Root       : ' . static::$root;
@@ -257,6 +258,8 @@ trait LocationsTrait {
       })
       ->exclude($exclusions);
 
+    $fs = new Filesystem();
+
     foreach ($finder as $file) {
       $src_path = $file->getRealPath();
       $dst_path = $dst . DIRECTORY_SEPARATOR . $file->getRelativePathname();
@@ -265,7 +268,7 @@ trait LocationsTrait {
         $before($src_path, $dst_path);
       }
 
-      (new Filesystem())->copy($src_path, $dst_path);
+      $fs->copy($src_path, $dst_path);
       $created[] = static::locationsRealpath($dst_path);
     }
 

--- a/src/Traits/LoggerTrait.php
+++ b/src/Traits/LoggerTrait.php
@@ -108,6 +108,9 @@ trait LoggerTrait {
    *   Whether to use double border characters (=) instead of single (-).
    * @param int $min_width
    *   Minimum width of the section.
+   *
+   * @throws \InvalidArgumentException
+   *   When the minimum width is not a positive integer.
    */
   public static function logSection(string $title, ?string $message = NULL, bool $double_border = FALSE, int $min_width = 60): void {
     if ($min_width <= 0) {

--- a/src/Traits/LoggerTrait.php
+++ b/src/Traits/LoggerTrait.php
@@ -119,14 +119,8 @@ trait LoggerTrait {
     if (!static::$loggerIsVerbose) {
       return;
     }
-    if ($double_border) {
-      $delimiter_char = '=';
-      $header_format = '[ %s ]';
-    }
-    else {
-      $delimiter_char = '-';
-      $header_format = '[ %s ]';
-    }
+    $delimiter_char = $double_border ? '=' : '-';
+    $header_format = '[ %s ]';
 
     $header = sprintf($header_format, $title);
     $header_length = strlen($header);

--- a/src/Traits/LoggerTrait.php
+++ b/src/Traits/LoggerTrait.php
@@ -125,19 +125,15 @@ trait LoggerTrait {
     $header = sprintf($header_format, $title);
     $header_length = strlen($header);
 
-    // Ensure minimum 3 characters on each side of the header.
     $min_padding = 3;
     $total_length = max($min_width, $header_length + (2 * $min_padding));
 
-    // Calculate padding for centering.
     $padding_length = ($total_length - $header_length) / 2;
     $left_padding = max($min_padding, (int) ceil($padding_length));
     $right_padding = max($min_padding, (int) floor($padding_length));
 
-    // Create the top delimiter line.
     $top_line = str_repeat($delimiter_char, $left_padding) . $header . str_repeat($delimiter_char, $right_padding);
 
-    // Create the bottom delimiter line.
     $bottom_line = str_repeat($delimiter_char, strlen($top_line));
 
     fwrite(static::getOutputStream(), PHP_EOL . $top_line . PHP_EOL);
@@ -146,7 +142,6 @@ trait LoggerTrait {
       $message = trim($message);
       $header_width = strlen($top_line);
 
-      // Word wrap the message to match the header width.
       $wrapped_lines = [];
       $lines = explode(PHP_EOL, $message);
 
@@ -155,13 +150,11 @@ trait LoggerTrait {
           $wrapped_lines[] = $line;
         }
         else {
-          // Use wordwrap to split long lines.
           $wrapped = wordwrap($line, $header_width, "\n", FALSE);
           $wrapped_lines = array_merge($wrapped_lines, explode("\n", $wrapped));
         }
       }
 
-      // Output the wrapped message lines.
       foreach ($wrapped_lines as $line) {
         fwrite(static::getOutputStream(), $line . PHP_EOL);
       }
@@ -213,10 +206,8 @@ trait LoggerTrait {
     $trace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 2);
     $step = $trace[1]['function'] ?? 'unknown';
 
-    // Capture current parent stack for hierarchy.
     $parent_stack = static::$loggerStepStack;
 
-    // Add step to tracking array with hierarchy information.
     static::$loggerSteps[] = [
       'name' => $step,
       'start_time' => microtime(TRUE),
@@ -225,7 +216,6 @@ trait LoggerTrait {
       'parent_stack' => $parent_stack,
     ];
 
-    // Push current step onto the stack for nested steps.
     static::$loggerStepStack[] = $step;
 
     $prefix = str_starts_with($step, static::$loggerStepMethodPrefix) ? sprintf('%s START', strtoupper(static::$loggerStepMethodPrefix)) : 'STEP START';
@@ -246,12 +236,10 @@ trait LoggerTrait {
     $trace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 2);
     $step = $trace[1]['function'] ?? 'unknown';
 
-    // Find the most recent unfinished step with matching name.
     $prefix = str_starts_with($step, static::$loggerStepMethodPrefix) ? sprintf('%s DONE', strtoupper(static::$loggerStepMethodPrefix)) : 'STEP DONE';
     $section_title = $prefix . ' | ' . $step;
     $step_index = NULL;
 
-    // Search backwards for the most recent matching step.
     for ($i = count(static::$loggerSteps) - 1; $i >= 0; $i--) {
       if (static::$loggerSteps[$i]['name'] === $step && static::$loggerSteps[$i]['end_time'] === NULL) {
         $step_index = $i;
@@ -264,14 +252,11 @@ trait LoggerTrait {
       $elapsed_time = $end_time - static::$loggerSteps[$step_index]['start_time'];
       $formatted_time = static::formatElapsedTime($elapsed_time);
 
-      // Update the step entry with completion info.
       static::$loggerSteps[$step_index]['end_time'] = $end_time;
       static::$loggerSteps[$step_index]['elapsed'] = $elapsed_time;
 
       $section_title .= ' | ' . $formatted_time;
 
-      // Pop the step from the stack when it finishes.
-      // Find and remove the step from the stack.
       $stack_key = array_search($step, static::$loggerStepStack, TRUE);
       if ($stack_key !== FALSE) {
         array_splice(static::$loggerStepStack, (int) $stack_key, 1);
@@ -326,7 +311,6 @@ trait LoggerTrait {
 
     $lines = [];
 
-    // Calculate column widths including indentation.
     $name_lengths = array_map(function (array $step) use ($indent): int {
       $depth = count($step['parent_stack']);
       $indentation = str_repeat($indent, $depth);
@@ -341,7 +325,6 @@ trait LoggerTrait {
     // "Elapsed" header length
     $max_elapsed_length = 7;
 
-    // Create table header.
     $header = sprintf(
       '| %-' . $max_name_length . 's | %-' . $max_status_length . 's | %-' . $max_elapsed_length . 's |',
       'Step',
@@ -353,17 +336,14 @@ trait LoggerTrait {
       str_repeat('-', $max_status_length + 2) . '+' .
       str_repeat('-', $max_elapsed_length + 2) . '+';
 
-    // Build table output.
     $lines[] = $separator;
     $lines[] = $header;
     $lines[] = $separator;
 
-    // Create table rows with hierarchical indentation.
     foreach (static::$loggerSteps as $step) {
       $status = $step['end_time'] === NULL ? 'Running' : 'Complete';
       $elapsed = $step['elapsed'] === NULL ? '-' : static::formatElapsedTime($step['elapsed']);
 
-      // Calculate depth and add indentation.
       $depth = count($step['parent_stack']);
       $indentation = str_repeat($indent, $depth);
       $indented_name = $indentation . $step['name'];

--- a/src/Traits/LoggerTrait.php
+++ b/src/Traits/LoggerTrait.php
@@ -6,6 +6,8 @@ namespace AlexSkrypnyk\PhpunitHelpers\Traits;
 
 /**
  * Provides logging functionality.
+ *
+ * @mixin \PHPUnit\Framework\TestCase
  */
 trait LoggerTrait {
 
@@ -316,6 +318,9 @@ trait LoggerTrait {
    *
    * @param string $indent
    *   Indentation string for hierarchical display (e.g., '  ', '    ', '\t').
+   *
+   * @return string
+   *   The formatted summary table.
    */
   public static function logStepSummary(string $indent = '  '): string {
     if (empty(static::$loggerSteps)) {

--- a/src/Traits/ProcessTrait.php
+++ b/src/Traits/ProcessTrait.php
@@ -352,7 +352,7 @@ trait ProcessTrait {
    * Checks if the process completed with a successful exit code and provides
    * detailed error output if it failed.
    *
-   * @param string|null $message
+   * @param ?string $message
    *   Optional message to include in the failure output if the process failed.
    */
   public function assertProcessSuccessful(?string $message = NULL): void {
@@ -369,7 +369,7 @@ trait ProcessTrait {
    * Checks if the process failed and provides detailed output if it
    * unexpectedly succeeded.
    *
-   * @param string|null $message
+   * @param ?string $message
    *   Optional message to include in the failure output if the process
    *   succeeded.
    */
@@ -470,7 +470,7 @@ trait ProcessTrait {
   /**
    * Asserts that the process error output contains an expected string.
    *
-   * @param string $expected
+   * @param array|string $expected
    *   Expected string to check for in the process error output.
    * @param ?string $message
    *   Optional failure message.
@@ -497,7 +497,7 @@ trait ProcessTrait {
   /**
    * Asserts that the process error output does not contain an expected string.
    *
-   * @param string $expected
+   * @param array|string $expected
    *   String that should not be in the process error output.
    * @param ?string $message
    *   Optional failure message.
@@ -534,7 +534,7 @@ trait ProcessTrait {
    * - Shortcut mode: No prefixes, all strings treated as substring present
    * - Mixed mode: If any string has a prefix, ALL strings must have prefixes
    *
-   * @param string|array $expected
+   * @param array|string $expected
    *   String or array of strings to check in the process output.
    *   Use '+ ' prefix for exact match present,
    *   '* ' prefix for substring present,
@@ -547,7 +547,7 @@ trait ProcessTrait {
    * @throws \RuntimeException
    *   When prefix usage is inconsistent (some have prefixes, others don't).
    */
-  public function assertProcessOutputContainsOrNot(string|array $expected, ?string $message = NULL): void {
+  public function assertProcessOutputContainsOrNot(array|string $expected, ?string $message = NULL): void {
     $this->assertNotNull($this->process, 'Process is not initialized');
 
     $output = $this->process->getOutput();
@@ -577,7 +577,7 @@ trait ProcessTrait {
    * - Shortcut mode: No prefixes, all strings treated as substring present
    * - Mixed mode: If any string has a prefix, ALL strings must have prefixes
    *
-   * @param string|array $expected
+   * @param array|string $expected
    *   String or array of strings to check in the process error output.
    *   Use '+ ' prefix for exact match present,
    *   '* ' prefix for substring present,
@@ -590,7 +590,7 @@ trait ProcessTrait {
    * @throws \RuntimeException
    *   When prefix usage is inconsistent (some have prefixes, others don't).
    */
-  public function assertProcessErrorOutputContainsOrNot(string|array $expected, ?string $message = NULL): void {
+  public function assertProcessErrorOutputContainsOrNot(array|string $expected, ?string $message = NULL): void {
     $this->assertNotNull($this->process, 'Process is not initialized');
 
     $output = $this->process->getErrorOutput();
@@ -683,7 +683,7 @@ trait ProcessTrait {
    * - Shortcut mode: No prefixes, all strings treated as substring present
    * - Mixed mode: If any string has a prefix, ALL strings must have prefixes
    *
-   * @param string|array $expected
+   * @param array|string $expected
    *   String or array of strings to check in combined process output.
    *   Use '+ ' prefix for exact match present,
    *   '* ' prefix for substring present,
@@ -696,7 +696,7 @@ trait ProcessTrait {
    * @throws \RuntimeException
    *   When prefix usage is inconsistent (some have prefixes, others don't).
    */
-  public function assertProcessAnyOutputContainsOrNot(string|array $expected, ?string $message = NULL): void {
+  public function assertProcessAnyOutputContainsOrNot(array|string $expected, ?string $message = NULL): void {
     $this->assertNotNull($this->process, 'Process is not initialized');
 
     $output = $this->process->getOutput();

--- a/src/Traits/ProcessTrait.php
+++ b/src/Traits/ProcessTrait.php
@@ -301,9 +301,9 @@ trait ProcessTrait {
       $prefix = $type === Process::ERR ? static::$processStreamingErrorOutputChars : static::$processStreamingStandardOutputChars;
 
       $parts = preg_split('/(\r\n|\n|\r)/', $buffer, -1, PREG_SPLIT_DELIM_CAPTURE);
-      $counter = is_array($parts) ? count($parts) : 0;
+      $count = is_array($parts) ? count($parts) : 0;
 
-      for ($i = 0; $i < $counter; $i += 2) {
+      for ($i = 0; $i < $count; $i += 2) {
         $line = $parts[$i] ?? '';
         $eol = $parts[$i + 1] ?? '';
 

--- a/src/Traits/ProcessTrait.php
+++ b/src/Traits/ProcessTrait.php
@@ -153,7 +153,7 @@ trait ProcessTrait {
       }
     }
 
-    $cmd = array_merge([$base_command], $all_arguments);
+    $full_command = array_merge([$base_command], $all_arguments);
 
     $inputs = empty($inputs) ? NULL : implode(PHP_EOL, $inputs) . PHP_EOL;
 
@@ -163,7 +163,7 @@ trait ProcessTrait {
     }
 
     $this->process = new Process(
-      $cmd,
+      $full_command,
       $this->processCwd,
       $env,
       $inputs,

--- a/src/Traits/ProcessTrait.php
+++ b/src/Traits/ProcessTrait.php
@@ -67,8 +67,6 @@ trait ProcessTrait {
 
   /**
    * Dim the streaming output.
-   *
-   * This makes the streaming output less prominent in the console.
    */
   protected static bool $processStreamingOutputShouldDim = TRUE;
 
@@ -131,12 +129,10 @@ trait ProcessTrait {
     int $timeout = 60,
     int $idle_timeout = 30,
   ): Process {
-    // Parse command string to extract command and arguments as a shortcut.
     $parsed_command = $this->processParseCommand($command);
     $base_command = array_shift($parsed_command);
     $parsed_arguments = $parsed_command;
 
-    // Validate the base command contains only allowed characters.
     if (preg_match('/[^a-zA-Z0-9_\-.\/]/', $base_command)) {
       throw new \InvalidArgumentException(sprintf('Invalid command: %s. Only alphanumeric characters, dots, dashes, underscores and slashes are allowed.', $base_command));
     }
@@ -151,8 +147,8 @@ trait ProcessTrait {
     }
     unset($arg);
 
-    // Processes inherit all the env vars defined in the system. This can be
-    // prevented by setting to FALSE the env vars that need to be removed.
+    // The process inherits all system env vars. Setting a var to FALSE
+    // removes it from the inherited environment.
     foreach ($env as &$env_value) {
       if (!is_scalar($env_value)) {
         throw new \InvalidArgumentException('All environment variables must be scalar values.');
@@ -200,10 +196,10 @@ trait ProcessTrait {
    * stops option parsing and treats all subsequent tokens as positional
    * arguments.
    *
-   * Note: This parser intentionally allows backslash escaping inside single
-   * quotes (e.g., 'It\'s working'), which deviates from POSIX shell behavior
-   * where backslashes are literal inside single quotes. This provides more
-   * intuitive escaping for users.
+   * The parser deliberately allows backslash escaping inside single quotes
+   * (e.g., 'It\'s working'). POSIX shells treat backslashes inside single
+   * quotes as literal; the deviation makes escaping more intuitive for
+   * users.
    *
    * @param string $command
    *   The command string to parse.
@@ -259,11 +255,9 @@ trait ProcessTrait {
 
       if (!$in_quotes && ($char === ' ' || $char === "\t")) {
         if ($current !== '' || $has_content) {
-          // Check for end-of-options marker (--) only if not already found
-          // and not inside quotes.
           if (!$end_of_options_found && $current === '--') {
             $end_of_options_found = TRUE;
-            // Add the -- marker to the parts array so it reaches the command.
+            // Keep the -- marker so the command receives it.
             $parts[] = $current;
             $current = '';
             $has_content = FALSE;

--- a/src/Traits/ProcessTrait.php
+++ b/src/Traits/ProcessTrait.php
@@ -77,6 +77,9 @@ trait ProcessTrait {
    *
    * @return \Symfony\Component\Process\Process
    *   The currently running process.
+   *
+   * @throws \RuntimeException
+   *   When the process is not initialized.
    */
   public function processGet(): Process {
     if (!$this->process instanceof Process) {
@@ -116,6 +119,9 @@ trait ProcessTrait {
    *
    * @return \Symfony\Component\Process\Process
    *   The completed process.
+   *
+   * @throws \InvalidArgumentException
+   *   When the command, arguments or environment variables are invalid.
    */
   public function processRun(
     string $command,
@@ -204,6 +210,9 @@ trait ProcessTrait {
    *
    * @return array
    *   Array with command as first element and arguments as subsequent elements.
+   *
+   * @throws \InvalidArgumentException
+   *   When the command string is empty or malformed.
    */
   protected function processParseCommand(string $command): array {
     $command = trim($command);

--- a/src/Traits/ProcessTrait.php
+++ b/src/Traits/ProcessTrait.php
@@ -145,7 +145,7 @@ trait ProcessTrait {
 
     foreach ($all_arguments as &$arg) {
       if (!is_scalar($arg)) {
-        throw new \InvalidArgumentException("All arguments must be scalar values.");
+        throw new \InvalidArgumentException('All arguments must be scalar values.');
       }
       $arg = (string) $arg;
     }
@@ -155,7 +155,7 @@ trait ProcessTrait {
     // prevented by setting to FALSE the env vars that need to be removed.
     foreach ($env as &$env_value) {
       if (!is_scalar($env_value)) {
-        throw new \InvalidArgumentException("All environment variables must be scalar values.");
+        throw new \InvalidArgumentException('All environment variables must be scalar values.');
       }
     }
 
@@ -306,7 +306,7 @@ trait ProcessTrait {
    *   The output processing callback.
    */
   protected function processStreamingOutputCallback(): callable {
-    return function ($type, $buffer): void {
+    return function (string $type, string $buffer): void {
       $prefix = $type === Process::ERR ? static::$processStreamingErrorOutputChars : static::$processStreamingStandardOutputChars;
 
       $parts = preg_split('/(\r\n|\n|\r)/', $buffer, -1, PREG_SPLIT_DELIM_CAPTURE);

--- a/src/Traits/ProcessTrait.php
+++ b/src/Traits/ProcessTrait.php
@@ -356,7 +356,7 @@ trait ProcessTrait {
    *   Optional message to include in the failure output if the process failed.
    */
   public function assertProcessSuccessful(?string $message = NULL): void {
-    $this->assertNotNull($this->process, 'Process should be initialized');
+    $this->assertNotNull($this->process, 'Process is not initialized');
 
     if (!$this->process->isSuccessful()) {
       $this->fail('PROCESS FAILED' . PHP_EOL . ($message ? 'Message: ' . $message . PHP_EOL : '') . $this->processFormatOutput() . $this->assertionSuffix());

--- a/src/Traits/ReflectionTrait.php
+++ b/src/Traits/ReflectionTrait.php
@@ -26,6 +26,10 @@ trait ReflectionTrait {
    *
    * @return mixed
    *   Method result.
+   *
+   * @throws \InvalidArgumentException
+   *   When the class or method does not exist or no object instance is
+   *   provided for a non-static method.
    */
   public static function callProtectedMethod(object|string $object, string $name, array $args = []): mixed {
     $object_or_class = is_object($object) ? $object::class : $object;

--- a/src/Traits/ReflectionTrait.php
+++ b/src/Traits/ReflectionTrait.php
@@ -5,8 +5,6 @@ declare(strict_types=1);
 namespace AlexSkrypnyk\PhpunitHelpers\Traits;
 
 /**
- * Trait ReflectionTrait.
- *
  * Provides methods to work with class reflection.
  *
  * @mixin \PHPUnit\Framework\TestCase
@@ -46,11 +44,8 @@ trait ReflectionTrait {
 
     $method = $class->getMethod($name);
 
-    // If the method is static, we won't pass an object instance to invokeArgs()
-    // Otherwise, we ensure to pass the object instance.
     $invoke_object = $method->isStatic() ? NULL : (is_object($object) ? $object : NULL);
 
-    // Ensure we have an object for non-static methods.
     if (!$method->isStatic() && $invoke_object === NULL) {
       throw new \InvalidArgumentException('An object instance is required for non-static methods');
     }
@@ -64,7 +59,7 @@ trait ReflectionTrait {
    * @param object $object
    *   Object to set the value on.
    * @param string $property
-   *   Property name to set the value. Property should exists in the object.
+   *   Property name to set the value. Property should exist in the object.
    * @param mixed $value
    *   Value to set to the property.
    */
@@ -81,7 +76,7 @@ trait ReflectionTrait {
    * @param object $object
    *   Object to set the value on.
    * @param string $property
-   *   Property name to get the value. Property should exists in the object.
+   *   Property name to get the value. Property should exist in the object.
    *
    * @return mixed
    *   Protected property value.

--- a/src/Traits/ReflectionTrait.php
+++ b/src/Traits/ReflectionTrait.php
@@ -52,7 +52,7 @@ trait ReflectionTrait {
 
     // Ensure we have an object for non-static methods.
     if (!$method->isStatic() && $invoke_object === NULL) {
-      throw new \InvalidArgumentException("An object instance is required for non-static methods");
+      throw new \InvalidArgumentException('An object instance is required for non-static methods');
     }
 
     return $method->invokeArgs($invoke_object, $args);
@@ -68,7 +68,7 @@ trait ReflectionTrait {
    * @param mixed $value
    *   Value to set to the property.
    */
-  public static function setProtectedValue($object, $property, mixed $value): void {
+  public static function setProtectedValue(object $object, string $property, mixed $value): void {
     $class = new \ReflectionClass($object::class);
     $property = $class->getProperty($property);
 
@@ -86,7 +86,7 @@ trait ReflectionTrait {
    * @return mixed
    *   Protected property value.
    */
-  public static function getProtectedValue($object, $property): mixed {
+  public static function getProtectedValue(object $object, string $property): mixed {
     $class = new \ReflectionClass($object::class);
     $property = $class->getProperty($property);
 

--- a/src/Traits/ReflectionTrait.php
+++ b/src/Traits/ReflectionTrait.php
@@ -8,6 +8,8 @@ namespace AlexSkrypnyk\PhpunitHelpers\Traits;
  * Trait ReflectionTrait.
  *
  * Provides methods to work with class reflection.
+ *
+ * @mixin \PHPUnit\Framework\TestCase
  */
 trait ReflectionTrait {
 

--- a/src/Traits/SerializableClosureTrait.php
+++ b/src/Traits/SerializableClosureTrait.php
@@ -7,10 +7,7 @@ namespace AlexSkrypnyk\PhpunitHelpers\Traits;
 use Laravel\SerializableClosure\SerializableClosure;
 
 /**
- * Trait SerializableClosureTrait.
- *
- * Provides a wrapper for closures that allows to use them as arguments in data
- * providers.
+ * Provides a wrapper to pass closures as arguments in data providers.
  *
  * The methods are deliberately named as short as possible to avoid long lines
  * in data providers:

--- a/src/Traits/StringTrait.php
+++ b/src/Traits/StringTrait.php
@@ -24,7 +24,7 @@ trait StringTrait {
    *
    * @param string $haystack
    *   The string to search in.
-   * @param string|array $expected
+   * @param array|string $expected
    *   String or array of strings to check with optional prefixes.
    * @param string $message_present_exact
    *   Message template for failed exact match present assertions.
@@ -54,7 +54,7 @@ trait StringTrait {
    */
   protected function assertStringContainsOrNot(
     string $haystack,
-    string|array $expected,
+    array|string $expected,
     string $message_present_exact = 'Expected exact match for "%s" in haystack',
     string $message_present_contains = 'Expected substring "%s" in haystack',
     string $message_absent_exact = 'Expected no exact match for "%s" in haystack',

--- a/src/Traits/StringTrait.php
+++ b/src/Traits/StringTrait.php
@@ -5,8 +5,6 @@ declare(strict_types=1);
 namespace AlexSkrypnyk\PhpunitHelpers\Traits;
 
 /**
- * Trait StringTrait.
- *
  * Provides string assertion utilities with prefix support.
  *
  * @mixin \PHPUnit\Framework\TestCase
@@ -89,20 +87,17 @@ trait StringTrait {
       return;
     }
 
-    // Determine mode by checking for any prefixes.
     $has_prefix_count = 0;
     foreach ($expected as $value) {
       foreach ($prefixes as $prefix) {
         $prefix_with_separator = $prefix . $prefix_separator;
         if ($prefix_separator === '') {
-          // When separator is empty, check only prefix.
           if (str_starts_with($value, $prefix)) {
             $has_prefix_count++;
             break;
           }
         }
         elseif (str_starts_with($value, $prefix_with_separator)) {
-          // When separator exists, check prefix + separator.
           $has_prefix_count++;
           break;
         }
@@ -111,7 +106,6 @@ trait StringTrait {
 
     $mixed_mode = $has_prefix_count > 0;
 
-    // In mixed mode, all values must have valid prefixes.
     if ($mixed_mode && $has_prefix_count !== count($expected)) {
       $first_invalid = NULL;
       foreach ($expected as $value) {
@@ -119,14 +113,12 @@ trait StringTrait {
         foreach ($prefixes as $prefix) {
           $prefix_with_separator = $prefix . $prefix_separator;
           if ($prefix_separator === '') {
-            // When separator is empty, check only prefix.
             if (str_starts_with($value, $prefix)) {
               $has_valid_prefix = TRUE;
               break;
             }
           }
           elseif (str_starts_with($value, $prefix_with_separator)) {
-            // When separator exists, check prefix + separator.
             $has_valid_prefix = TRUE;
             break;
           }
@@ -139,16 +131,13 @@ trait StringTrait {
       throw new \RuntimeException(sprintf('All strings must have valid prefixes in mixed mode. First invalid: "%s"', $first_invalid));
     }
 
-    // Process each expected value.
     foreach ($expected as $expected_value) {
       if ($mixed_mode) {
-        // Find which prefix matches this value.
         $prefix = NULL;
         $value = NULL;
         foreach ($prefixes as $test_prefix) {
           $prefix_with_separator = $test_prefix . $prefix_separator;
           if ($prefix_separator === '') {
-            // When separator is empty, check only prefix.
             if (str_starts_with($expected_value, $test_prefix)) {
               $prefix = $test_prefix;
               $value = substr($expected_value, strlen($test_prefix));
@@ -156,14 +145,12 @@ trait StringTrait {
             }
           }
           elseif (str_starts_with($expected_value, $prefix_with_separator)) {
-            // When separator exists, check prefix + separator.
             $prefix = $test_prefix;
             $value = substr($expected_value, strlen($prefix_with_separator));
             break;
           }
         }
 
-        // Validate value is not empty after stripping prefix.
         if ($value === '') {
           throw new \RuntimeException(sprintf('Value cannot be empty after stripping prefix: "%s"', $expected_value));
         }
@@ -174,7 +161,6 @@ trait StringTrait {
         $value = $expected_value;
       }
 
-      // Perform the appropriate assertion based on prefix type.
       if ($prefix === $prefix_present_exact) {
         $message = sprintf($message_present_exact, $value);
         if ($case_insensitive) {

--- a/src/Traits/TuiTrait.php
+++ b/src/Traits/TuiTrait.php
@@ -49,7 +49,7 @@ trait TuiTrait {
    *
    * @var array
    */
-  public const KEYS = [
+  const KEYS = [
     'UP' => "\e[A",
     'SHIFT_UP' => "\e[1;2A",
     'DOWN' => "\e[B",
@@ -191,7 +191,7 @@ trait TuiTrait {
       // If an entry has a special key - we consider that any additional
       // functionality like clearing the existing entry or appending an accept
       // key is handled by the consumer.
-      $skip_additional_processing = static::tuiHasKey($entry, [self::KEYS['SPACE']]);
+      $skip_additional_processing = static::tuiHasKey($entry, [static::KEYS['SPACE']]);
 
       // Clear the existing TUI value, if any, one character at a time.
       if (!$skip_additional_processing && $clear_size > 0) {

--- a/src/Traits/TuiTrait.php
+++ b/src/Traits/TuiTrait.php
@@ -128,6 +128,9 @@ trait TuiTrait {
    *
    * @return array
    *   The processed TUI entries.
+   *
+   * @throws \InvalidArgumentException
+   *   When an entry value is not scalar.
    */
   public static function tuiEntries(array $entries, string $default = ''): array {
     foreach ($entries as $key => $value) {
@@ -160,6 +163,9 @@ trait TuiTrait {
    *
    * @return array
    *   The processed TUI entries as keystrokes.
+   *
+   * @throws \RuntimeException
+   *   When a TUI_SKIP entry was not filtered out.
    */
   public static function tuiKeystrokes(array $entries, int $clear_size = 0, ?string $accept_key = NULL, ?string $clear_key = NULL): array {
     $accept_key ??= static::KEYS['ENTER'];

--- a/src/Traits/TuiTrait.php
+++ b/src/Traits/TuiTrait.php
@@ -93,7 +93,7 @@ trait TuiTrait {
    * An entry will not be included in the resulting array of entries if it has
    * this value.
    *
-   * @var null|string
+   * @var string
    */
   const TUI_SKIP = '__SKIP__';
 

--- a/src/Traits/TuiTrait.php
+++ b/src/Traits/TuiTrait.php
@@ -188,12 +188,10 @@ trait TuiTrait {
 
       $entry_keystrokes = [];
 
-      // If an entry has a special key - we consider that any additional
-      // functionality like clearing the existing entry or appending an accept
-      // key is handled by the consumer.
+      // For an entry containing a special key, clearing the existing entry
+      // and appending an accept key are handled by the consumer.
       $skip_additional_processing = static::tuiHasKey($entry, [static::KEYS['SPACE']]);
 
-      // Clear the existing TUI value, if any, one character at a time.
       if (!$skip_additional_processing && $clear_size > 0) {
         $entry_keystrokes = array_fill(0, $clear_size, $clear_key);
       }
@@ -201,7 +199,6 @@ trait TuiTrait {
       $split_entry = static::tuiEntryToKeystroke($entry);
       $entry_keystrokes = array_merge($entry_keystrokes, $split_entry);
 
-      // Add the accept key at the end of the entry if it is not already there.
       if (!$skip_additional_processing && end($entry_keystrokes) !== $accept_key) {
         $entry_keystrokes[] = $accept_key;
       }
@@ -268,7 +265,6 @@ trait TuiTrait {
   public static function tuiHasKey(string $value, array $exclude = []): bool {
     $flattened_keys = static::tuiKeysFlattened();
 
-    // Exclude specified keys from the check.
     if (!empty($exclude)) {
       $flattened_keys = array_diff($flattened_keys, $exclude);
     }

--- a/src/Traits/TuiTrait.php
+++ b/src/Traits/TuiTrait.php
@@ -39,6 +39,8 @@ namespace AlexSkrypnyk\PhpunitHelpers\Traits;
  * // Convert entries to keystrokes if needed.
  * my_tui_run_keystrokes(static::tuiKeystrokes($entries_set1));
  * @endcode
+ *
+ * @mixin \PHPUnit\Framework\TestCase
  */
 trait TuiTrait {
 

--- a/src/UnitTestCase.php
+++ b/src/UnitTestCase.php
@@ -19,8 +19,8 @@ use PHPUnit\Framework\TestStatus\Failure;
  */
 abstract class UnitTestCase extends TestCase {
 
-  use ReflectionTrait;
   use LocationsTrait;
+  use ReflectionTrait;
 
   /**
    * {@inheritdoc}

--- a/src/UnitTestCase.php
+++ b/src/UnitTestCase.php
@@ -11,11 +11,9 @@ use PHPUnit\Framework\TestStatus\Error;
 use PHPUnit\Framework\TestStatus\Failure;
 
 /**
- * Class UnitTestCase.
- *
  * Base class for unit tests.
  *
- * Use DEBUG=1 to prevent cleanup of the temp directories
+ * DEBUG=1 prevents cleanup of the temp directories.
  */
 abstract class UnitTestCase extends TestCase {
 
@@ -70,7 +68,6 @@ abstract class UnitTestCase extends TestCase {
    *   The additional information.
    */
   public function info(): string {
-    // Collect all methods of the class that end with 'Info'.
     $methods = array_values(array_filter(get_class_methods(static::class), fn(string $m): bool => !str_contains($m, 'test') && str_ends_with($m, 'Info')));
 
     $info = '';
@@ -102,12 +99,8 @@ abstract class UnitTestCase extends TestCase {
   /**
    * Suffix to be added to all assertion failure messages.
    *
-   * This is to overcome the limitation of PHPUnit not allowing to alter
-   * the message within the assertion Throwable in onNotSuccessfulTest().
-   *
-   * onNotSuccessfulTest() currently only allows to print to stdout/stderr
-   * right after the test failure rather than collecting all information and
-   * appending it to the failure message.
+   * Works around a PHPUnit limitation: onNotSuccessfulTest() cannot alter
+   * the message within the assertion Throwable.
    *
    * @return string
    *   The assertion suffix.

--- a/src/UnitTestCase.php
+++ b/src/UnitTestCase.php
@@ -40,6 +40,9 @@ abstract class UnitTestCase extends TestCase {
 
   /**
    * Determine if tearDown should clean up the temporary directories.
+   *
+   * @return bool
+   *   TRUE if the temporary directories should be cleaned up.
    */
   protected function tearDownShouldCleanup(): bool {
     return !$this->status() instanceof Failure && !$this->status() instanceof Error && !static::isDebug();
@@ -62,6 +65,9 @@ abstract class UnitTestCase extends TestCase {
    *
    * Collects and returns information from all methods in the class that end
    * with 'Info'.
+   *
+   * @return string
+   *   The additional information.
    */
   public function info(): string {
     // Collect all methods of the class that end with 'Info'.
@@ -102,6 +108,9 @@ abstract class UnitTestCase extends TestCase {
    * onNotSuccessfulTest() currently only allows to print to stdout/stderr
    * right after the test failure rather than collecting all information and
    * appending it to the failure message.
+   *
+   * @return string
+   *   The assertion suffix.
    */
   protected function assertionSuffix(): string {
     return $this->info();
@@ -109,6 +118,9 @@ abstract class UnitTestCase extends TestCase {
 
   /**
    * Check if the test is running in debug mode.
+   *
+   * @return bool
+   *   TRUE if debug mode is enabled, FALSE otherwise.
    */
   public static function isDebug(): bool {
     return getenv('DEBUG') || in_array('--debug', (array) ($_SERVER['argv'] ?? []));

--- a/tests/Fixtures/Application/Command/ErrorOutputCommand.php
+++ b/tests/Fixtures/Application/Command/ErrorOutputCommand.php
@@ -23,7 +23,6 @@ class ErrorOutputCommand extends Command {
    * {@inheritdoc}
    */
   protected function execute(InputInterface $input, OutputInterface $output): int {
-    // Use ConsoleOutput if it's available, otherwise write to stderr.
     if ($output instanceof ConsoleOutputInterface) {
       $error_output = $output->getErrorOutput();
       $error_output->writeln('Test Error');

--- a/tests/Fixtures/Application/Command/ExceptionOutputCommand.php
+++ b/tests/Fixtures/Application/Command/ExceptionOutputCommand.php
@@ -23,10 +23,8 @@ class ExceptionOutputCommand extends Command {
    * {@inheritdoc}
    */
   protected function execute(InputInterface $input, OutputInterface $output): int {
-    // Write to standard output.
     $output->writeln('Standard output before exception');
 
-    // Write to error output.
     if ($output instanceof ConsoleOutputInterface) {
       $error_output = $output->getErrorOutput();
       $error_output->writeln('Error output before exception');
@@ -35,7 +33,6 @@ class ExceptionOutputCommand extends Command {
       fwrite(STDERR, "Error output before exception" . PHP_EOL);
     }
 
-    // Throw an exception.
     throw new \RuntimeException('Test exception message');
   }
 

--- a/tests/Fixtures/Application/Command/GreetingCommand.php
+++ b/tests/Fixtures/Application/Command/GreetingCommand.php
@@ -36,7 +36,6 @@ class GreetingCommand extends Command {
     $name = $input->getArgument('name');
     $yell = $input->getOption('yell');
 
-    // Convert name to string safely.
     $name_str = is_scalar($name) ? (string) $name : 'Unknown';
     $greeting = sprintf('Hello, %s!', $name_str);
 

--- a/tests/Fixtures/Application/loader.php
+++ b/tests/Fixtures/Application/loader.php
@@ -12,12 +12,10 @@ require_once dirname(__DIR__, 3) . '/vendor/autoload.php';
 use AlexSkrypnyk\PhpunitHelpers\Tests\Fixtures\Application\Command\GreetingCommand;
 use Symfony\Component\Console\Application;
 
-// Initialize the application.
 $application = new Application('Test Application', '1.0.0');
 $application->setAutoExit(FALSE);
 $application->setCatchExceptions(FALSE);
 
-// Add commands.
 $application->add(new GreetingCommand());
 
 // Execute the application if this file is run directly.

--- a/tests/Functional/LoggerTraitFunctionalTest.php
+++ b/tests/Functional/LoggerTraitFunctionalTest.php
@@ -22,10 +22,8 @@ final class LoggerTraitFunctionalTest extends UnitTestCase {
    */
   protected function setUp(): void {
     parent::setUp();
-    // Reset verbose state for each test.
     self::loggerSetVerbose(FALSE);
 
-    // Reset steps tracking arrays for each test.
     $reflection_class = new \ReflectionClass(self::class);
     $steps_property = $reflection_class->getProperty('loggerSteps');
     $steps_property->setValue(NULL, []);
@@ -38,7 +36,6 @@ final class LoggerTraitFunctionalTest extends UnitTestCase {
    * {@inheritdoc}
    */
   protected function tearDown(): void {
-    // Reset output stream to default.
     self::loggerSetOutputStream(NULL);
     parent::tearDown();
   }
@@ -50,7 +47,6 @@ final class LoggerTraitFunctionalTest extends UnitTestCase {
    */
   #[DoesNotPerformAssertions]
   public function testFunctionalBasicLogging(): void {
-    // Reset to default STDERR output.
     self::loggerSetOutputStream(NULL);
     self::loggerSetVerbose(TRUE);
 
@@ -65,7 +61,6 @@ final class LoggerTraitFunctionalTest extends UnitTestCase {
    */
   #[DoesNotPerformAssertions]
   public function testFunctionalStepWorkflow(): void {
-    // Reset to default STDERR output.
     self::loggerSetOutputStream(NULL);
     self::loggerSetVerbose(TRUE);
 
@@ -73,13 +68,12 @@ final class LoggerTraitFunctionalTest extends UnitTestCase {
     self::logSubstep('Loading configuration');
     self::logNote('Using default settings');
     self::logSubstep('Validating input');
-    // 0.5 second delay to show elapsed time.
+    // Delay long enough to show elapsed time.
     usleep(500000);
     self::logStepFinish('Data processing complete');
 
     self::logStepStart('Generating output');
     self::logNote('Creating report format');
-    // 0.2 second delay.
     usleep(200000);
     self::logStepFinish('Output generated successfully');
 
@@ -93,7 +87,6 @@ final class LoggerTraitFunctionalTest extends UnitTestCase {
    */
   #[DoesNotPerformAssertions]
   public function testFunctionalSectionFormatting(): void {
-    // Reset to default STDERR output.
     self::loggerSetOutputStream(NULL);
     self::loggerSetVerbose(TRUE);
 
@@ -110,17 +103,14 @@ final class LoggerTraitFunctionalTest extends UnitTestCase {
    */
   #[DoesNotPerformAssertions]
   public function testFunctionalFileLogging(): void {
-    // Reset to default STDERR output.
     self::loggerSetOutputStream(NULL);
     self::loggerSetVerbose(TRUE);
 
-    // Create a temporary test file.
     $temp_file = tempnam(sys_get_temp_dir(), 'logger_functional_test');
     file_put_contents($temp_file, "Sample file content\nLine 2\nLine 3\n");
 
     self::logFile($temp_file, 'Test configuration file');
 
-    // Clean up.
     unlink($temp_file);
   }
 
@@ -131,14 +121,11 @@ final class LoggerTraitFunctionalTest extends UnitTestCase {
    */
   #[DoesNotPerformAssertions]
   public function testFunctionalHierarchicalSteps(): void {
-    // Reset to default STDERR output.
     self::loggerSetOutputStream(NULL);
     self::loggerSetVerbose(TRUE);
 
-    // Start the main deployment process.
     $this->stepDeploymentProcess();
 
-    // Show hierarchical summary with default indentation.
     self::logStepSummary('DEPLOYMENT SUMMARY');
   }
 
@@ -150,13 +137,10 @@ final class LoggerTraitFunctionalTest extends UnitTestCase {
     self::log('Initializing deployment environment');
     self::logSection('DEPLOYMENT CONFIGURATION', 'Production environment settings loaded');
 
-    // Run database migration.
     $this->stepDatabaseMigration();
 
-    // Run application deployment.
     $this->stepApplicationDeployment();
 
-    // Run health checks.
     $this->stepHealthChecks();
 
     self::log('All deployment steps completed successfully');
@@ -173,13 +157,11 @@ final class LoggerTraitFunctionalTest extends UnitTestCase {
 
     self::logSubstep('Backing up current database');
     self::log('Creating backup: prod_backup_2025_01_15.sql');
-    // 1 second delay.
     sleep(1);
 
     self::logSubstep('Running migration scripts');
     self::logNote('Applying schema changes from v2.1 to v2.2');
 
-    // Create a temporary migration log file to demonstrate logFile.
     $temp_file = tempnam(sys_get_temp_dir(), 'migration_log');
     file_put_contents($temp_file, "Migration Log\n=============\n\n" .
       "2025-01-15 10:30:01 - Starting migration\n" .
@@ -188,10 +170,8 @@ final class LoggerTraitFunctionalTest extends UnitTestCase {
       "2025-01-15 10:30:45 - Migration completed successfully\n");
 
     self::logFile($temp_file, 'Database migration log');
-    // Clean up.
     unlink($temp_file);
 
-    // 2 second delay.
     sleep(2);
     self::log('Database schema updated successfully');
     self::logStepFinish('Database migration completed');
@@ -205,10 +185,8 @@ final class LoggerTraitFunctionalTest extends UnitTestCase {
     self::logSection('APPLICATION SERVER', 'Preparing production deployment', TRUE);
     self::logNote('Deploying to production server cluster');
     self::log('Uploading application files to web servers');
-    // 1 second delay.
     sleep(1);
 
-    // Run asset compilation as a nested step.
     $this->stepAssetCompilation();
 
     self::log('Restarting application services');
@@ -226,13 +204,11 @@ final class LoggerTraitFunctionalTest extends UnitTestCase {
     self::logSubstep('Compiling CSS files');
     self::logNote('Processing SCSS with node-sass compiler');
     self::log('Generated: dist/css/main.min.css (compressed, 45KB)');
-    // 2 second delay.
     sleep(2);
 
     self::logSubstep('Minifying JavaScript');
     self::logNote('Using terser for JS optimization');
 
-    // Create a temporary build log file.
     $build_file = tempnam(sys_get_temp_dir(), 'build_log');
     file_put_contents($build_file, "Asset Build Report\n==================\n\n" .
       "CSS Files Processed:\n" .
@@ -244,10 +220,8 @@ final class LoggerTraitFunctionalTest extends UnitTestCase {
       "Total savings: 67% reduction in file size\n");
 
     self::logFile($build_file, 'Asset compilation report');
-    // Clean up.
     unlink($build_file);
 
-    // 1 second delay.
     sleep(1);
     self::log('Asset optimization completed successfully');
     self::logStepFinish('Asset compilation completed');
@@ -263,7 +237,6 @@ final class LoggerTraitFunctionalTest extends UnitTestCase {
     self::logSubstep('Testing database connection');
     self::log('Connecting to production database cluster');
     self::logNote('Connection successful - latency: 2ms');
-    // 1 second delay.
     sleep(1);
 
     self::logSubstep('Verifying API endpoints');
@@ -272,7 +245,6 @@ final class LoggerTraitFunctionalTest extends UnitTestCase {
     self::logNote('  • GET /api/users → 200 OK');
     self::logNote('  • POST /api/auth → 200 OK');
 
-    // Create a health check results file.
     $health_file = tempnam(sys_get_temp_dir(), 'health_check');
     file_put_contents($health_file, "System Health Check Results\n" .
       "===========================\n\n" .
@@ -290,10 +262,8 @@ final class LoggerTraitFunctionalTest extends UnitTestCase {
       "Overall Status: ✓ ALL SYSTEMS OPERATIONAL\n");
 
     self::logFile($health_file, 'System health check results');
-    // Clean up.
     unlink($health_file);
 
-    // 2 second delay.
     sleep(2);
     self::log('All health checks completed successfully');
     self::logStepFinish('Health checks passed');

--- a/tests/Functional/LoggerTraitFunctionalTest.php
+++ b/tests/Functional/LoggerTraitFunctionalTest.php
@@ -25,10 +25,13 @@ final class LoggerTraitFunctionalTest extends UnitTestCase {
     // Reset verbose state for each test.
     self::loggerSetVerbose(FALSE);
 
-    // Reset steps tracking array for each test.
+    // Reset steps tracking arrays for each test.
     $reflection_class = new \ReflectionClass(self::class);
     $steps_property = $reflection_class->getProperty('loggerSteps');
     $steps_property->setValue(NULL, []);
+
+    $stack_property = $reflection_class->getProperty('loggerStepStack');
+    $stack_property->setValue(NULL, []);
   }
 
   /**

--- a/tests/Functional/LoggerTraitFunctionalTest.php
+++ b/tests/Functional/LoggerTraitFunctionalTest.php
@@ -142,7 +142,7 @@ final class LoggerTraitFunctionalTest extends UnitTestCase {
   /**
    * Main deployment process step.
    */
-  private function stepDeploymentProcess(): void {
+  protected function stepDeploymentProcess(): void {
     self::logStepStart('Starting main deployment workflow');
     self::log('Initializing deployment environment');
     self::logSection('DEPLOYMENT CONFIGURATION', 'Production environment settings loaded');
@@ -163,7 +163,7 @@ final class LoggerTraitFunctionalTest extends UnitTestCase {
   /**
    * Database migration step.
    */
-  private function stepDatabaseMigration(): void {
+  protected function stepDatabaseMigration(): void {
     self::logStepStart('Preparing database migration');
     self::log('Connecting to production database');
     self::logNote('Using read-only backup connection');
@@ -197,7 +197,7 @@ final class LoggerTraitFunctionalTest extends UnitTestCase {
   /**
    * Application deployment step.
    */
-  private function stepApplicationDeployment(): void {
+  protected function stepApplicationDeployment(): void {
     self::logStepStart('Deploying application to production');
     self::logSection('APPLICATION SERVER', 'Preparing production deployment', TRUE);
     self::logNote('Deploying to production server cluster');
@@ -216,7 +216,7 @@ final class LoggerTraitFunctionalTest extends UnitTestCase {
   /**
    * Asset compilation step (deeply nested).
    */
-  private function stepAssetCompilation(): void {
+  protected function stepAssetCompilation(): void {
     self::logStepStart('Compiling and optimizing assets');
     self::log('Initializing build environment');
 
@@ -253,7 +253,7 @@ final class LoggerTraitFunctionalTest extends UnitTestCase {
   /**
    * Health checks step.
    */
-  private function stepHealthChecks(): void {
+  protected function stepHealthChecks(): void {
     self::logStepStart('Running system health checks');
     self::logSection('POST-DEPLOYMENT VERIFICATION', 'Validating system functionality');
 

--- a/tests/Functional/LoggerTraitFunctionalTest.php
+++ b/tests/Functional/LoggerTraitFunctionalTest.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace AlexSkrypnyk\PhpunitHelpers\Tests\Functional;
 
-use PHPUnit\Framework\Attributes\DoesNotPerformAssertions;
 use AlexSkrypnyk\PhpunitHelpers\Traits\LoggerTrait;
 use AlexSkrypnyk\PhpunitHelpers\UnitTestCase;
 use PHPUnit\Framework\Attributes\CoversTrait;
+use PHPUnit\Framework\Attributes\DoesNotPerformAssertions;
 
 /**
  * Functional tests for LoggerTrait that output to real STDERR.

--- a/tests/Functional/ProcessTraitFunctionalTest.php
+++ b/tests/Functional/ProcessTraitFunctionalTest.php
@@ -17,17 +17,17 @@ final class ProcessTraitFunctionalTest extends UnitTestCase {
     $output = $this->runPhpunit(TRUE);
     $combined = $output['combined'];
 
-    // Assert streaming output appears when DEBUG=1.
+    // Streaming output appears when DEBUG=1.
     $this->assertStringContainsString('>> Success stdout', (string) $combined);
     $this->assertStringContainsString('XX Success stderr', (string) $combined);
     $this->assertStringContainsString('>> Failed stdout', (string) $combined);
     $this->assertStringContainsString('XX Failed stderr', (string) $combined);
 
-    // Assert onNotSuccessfulTest() debug output appears in stderr.
+    // The onNotSuccessfulTest() debug output appears in stderr.
     $this->assertStringContainsString('Error: ', (string) $output['stderr']);
     $this->assertStringContainsString('Additional information:', (string) $output['stderr']);
 
-    // Assert common failure output.
+    // Common failure output.
     $this->assertStringContainsString('PROCESS FAILED', (string) $combined);
     $this->assertStringContainsString('PROCESS SUCCEEDED but failure was expected', (string) $combined);
     $this->assertStringContainsString('Additional information:', (string) $combined);
@@ -35,19 +35,18 @@ final class ProcessTraitFunctionalTest extends UnitTestCase {
     $this->assertStringContainsString('Tests: 4', (string) $combined);
     $this->assertStringContainsString('Failures: 2', (string) $combined);
 
-    // Assert that actual process output appears in failure messages.
+    // Actual process output appears in failure messages.
     $this->assertStringContainsString('Success stdout', (string) $combined);
     $this->assertStringContainsString('Success stderr', (string) $combined);
     $this->assertStringContainsString('Failed stdout', (string) $combined);
     $this->assertStringContainsString('Failed stderr', (string) $combined);
 
-    // Assert that process output headers and footers appear.
+    // Process output headers and footers appear.
     $this->assertStringContainsString('⬇⬇⬇ STANDARD OUTPUT ⬇⬇⬇', (string) $combined);
     $this->assertStringContainsString('⬆⬆⬆ STANDARD OUTPUT ⬆⬆⬆', (string) $combined);
     $this->assertStringContainsString('▼▼▼ ERROR OUTPUT ▼▼▼', (string) $combined);
     $this->assertStringContainsString('▲▲▲ ERROR OUTPUT ▲▲▲', (string) $combined);
 
-    // Assert streaming timing.
     $this->assertStreamingTiming($output['real_time_output']);
   }
 
@@ -55,16 +54,16 @@ final class ProcessTraitFunctionalTest extends UnitTestCase {
     $output = $this->runPhpunit(FALSE);
     $combined = $output['combined'];
 
-    // Assert streaming output does NOT appear when DEBUG=0.
+    // Streaming output does not appear when DEBUG=0.
     $this->assertStringNotContainsString('>> Success stdout', (string) $combined);
     $this->assertStringNotContainsString('XX Success stderr', (string) $combined);
     $this->assertStringNotContainsString('>> Failed stdout', (string) $combined);
     $this->assertStringNotContainsString('XX Failed stderr', (string) $combined);
 
-    // Assert onNotSuccessfulTest() debug output does NOT appear when DEBUG=0.
+    // The onNotSuccessfulTest() debug output does not appear when DEBUG=0.
     $this->assertStringNotContainsString('Error: ', (string) $output['stderr']);
 
-    // Assert common failure output still appears.
+    // Common failure output still appears.
     $this->assertStringContainsString('PROCESS FAILED', (string) $combined);
     $this->assertStringContainsString('PROCESS SUCCEEDED but failure was expected', (string) $combined);
     $this->assertStringContainsString('Additional information:', (string) $combined);
@@ -72,13 +71,13 @@ final class ProcessTraitFunctionalTest extends UnitTestCase {
     $this->assertStringContainsString('Tests: 4', (string) $combined);
     $this->assertStringContainsString('Failures: 2', (string) $combined);
 
-    // Assert that actual process output appears in failure messages.
+    // Actual process output appears in failure messages.
     $this->assertStringContainsString('Success stdout', (string) $combined);
     $this->assertStringContainsString('Success stderr', (string) $combined);
     $this->assertStringContainsString('Failed stdout', (string) $combined);
     $this->assertStringContainsString('Failed stderr', (string) $combined);
 
-    // Assert that process output headers and footers appear.
+    // Process output headers and footers appear.
     $this->assertStringContainsString('⬇⬇⬇ STANDARD OUTPUT ⬇⬇⬇', (string) $combined);
     $this->assertStringContainsString('⬆⬆⬆ STANDARD OUTPUT ⬆⬆⬆', (string) $combined);
     $this->assertStringContainsString('▼▼▼ ERROR OUTPUT ▼▼▼', (string) $combined);

--- a/tests/Functional/ProcessTraitFunctionalTest.php
+++ b/tests/Functional/ProcessTraitFunctionalTest.php
@@ -90,7 +90,7 @@ final class ProcessTraitFunctionalTest extends UnitTestCase {
     $phpunit_bin = $vendor_dir . '/bin/phpunit';
 
     $env = $with_debug ? 'DEBUG=1' : 'DEBUG=0';
-    $cmd = sprintf('%s %s --no-coverage --group=manual', $env, $phpunit_bin);
+    $command = sprintf('%s %s --no-coverage --group=manual', $env, $phpunit_bin);
 
     $descriptors = [
       0 => ['pipe', 'r'],
@@ -98,7 +98,7 @@ final class ProcessTraitFunctionalTest extends UnitTestCase {
       2 => ['pipe', 'w'],
     ];
 
-    $process = proc_open($cmd, $descriptors, $pipes);
+    $process = proc_open($command, $descriptors, $pipes);
 
     if (!is_resource($process)) {
       $this->fail('Failed to start PHPUnit process');

--- a/tests/Functional/ProcessTraitFunctionalTest.php
+++ b/tests/Functional/ProcessTraitFunctionalTest.php
@@ -85,7 +85,7 @@ final class ProcessTraitFunctionalTest extends UnitTestCase {
     $this->assertStringContainsString('▲▲▲ ERROR OUTPUT ▲▲▲', (string) $combined);
   }
 
-  private function runPhpunit(bool $with_debug): array {
+  protected function runPhpunit(bool $with_debug): array {
     $vendor_dir = dirname(__DIR__, 2) . '/vendor';
     $phpunit_bin = $vendor_dir . '/bin/phpunit';
 
@@ -163,7 +163,7 @@ final class ProcessTraitFunctionalTest extends UnitTestCase {
     ];
   }
 
-  private function assertStreamingTiming(array $real_time_output): void {
+  protected function assertStreamingTiming(array $real_time_output): void {
     $streaming_phase = [];
     $final_phase = [];
 

--- a/tests/Functional/ProcessTraitScenariosTest.php
+++ b/tests/Functional/ProcessTraitScenariosTest.php
@@ -28,8 +28,8 @@ final class ProcessTraitScenariosTest extends UnitTestCase {
   }
 
   protected function tearDown(): void {
-    parent::tearDown();
     $this->processTearDown();
+    parent::tearDown();
   }
 
   /**

--- a/tests/Unit/ApplicationTraitTest.php
+++ b/tests/Unit/ApplicationTraitTest.php
@@ -780,10 +780,7 @@ final class ApplicationTraitTest extends UnitTestCase {
         $this->setName('test:multiline');
       }
 
-      protected function execute(
-        InputInterface $input,
-        OutputInterface $output,
-      ): int {
+      protected function execute(InputInterface $input, OutputInterface $output): int {
         $output->writeln('Line 1');
         $output->writeln('Line 2');
         $output->writeln('Line 3');

--- a/tests/Unit/ApplicationTraitTest.php
+++ b/tests/Unit/ApplicationTraitTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace AlexSkrypnyk\PhpunitHelpers\Tests\Unit;
 
-use Symfony\Component\Console\Exception\LogicException;
 use AlexSkrypnyk\PhpunitHelpers\Tests\Fixtures\Application\Command\ErrorOutputCommand;
 use AlexSkrypnyk\PhpunitHelpers\Tests\Fixtures\Application\Command\ExceptionOutputCommand;
 use AlexSkrypnyk\PhpunitHelpers\Tests\Fixtures\Application\Command\GreetingCommand;
@@ -16,6 +15,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\ExpectationFailedException;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Exception\LogicException;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Tester\ApplicationTester;

--- a/tests/Unit/ApplicationTraitTest.php
+++ b/tests/Unit/ApplicationTraitTest.php
@@ -54,14 +54,22 @@ final class ApplicationTraitTest extends UnitTestCase {
     $this->applicationInitFromLoader('/invalid/path/loader.php');
   }
 
-  public function testApplicationInitFromLoaderInvalidReturn(): void {
+  #[DataProvider('dataProviderApplicationInitFromLoaderInvalidReturn')]
+  public function testApplicationInitFromLoaderInvalidReturn(string $returned): void {
     $temp_file = self::$tmp . '/invalid_loader.php';
-    file_put_contents($temp_file, '<?php return null;');
+    file_put_contents($temp_file, '<?php return ' . $returned . ';');
 
     $this->expectException(\InvalidArgumentException::class);
     $this->expectExceptionMessage('Loader must return an instance of Application');
 
     $this->applicationInitFromLoader($temp_file);
+  }
+
+  public static function dataProviderApplicationInitFromLoaderInvalidReturn(): \Iterator {
+    yield 'null' => ['null'];
+    yield 'object_of_other_type' => ['new \stdClass()'];
+    yield 'scalar' => ["'not an application'"];
+    yield 'array' => ['[]'];
   }
 
   public function testApplicationInitWithCustomWorkingDirectory(): void {

--- a/tests/Unit/ApplicationTraitTest.php
+++ b/tests/Unit/ApplicationTraitTest.php
@@ -447,7 +447,7 @@ final class ApplicationTraitTest extends UnitTestCase {
 
       // The original directory is restored on shutdown, so the process is
       // still in the configured directory at this point.
-      $this->assertSame(realpath(self::$tmp), realpath((string) getcwd()));
+      $this->assertSame(self::locationsRealpath(self::$tmp), self::locationsRealpath((string) getcwd()));
     }
     finally {
       chdir($original_cwd);

--- a/tests/Unit/ApplicationTraitTest.php
+++ b/tests/Unit/ApplicationTraitTest.php
@@ -55,7 +55,6 @@ final class ApplicationTraitTest extends UnitTestCase {
   }
 
   public function testApplicationInitFromLoaderInvalidReturn(): void {
-    // Create a temporary file that returns null instead of an Application.
     $temp_file = self::$tmp . '/invalid_loader.php';
     file_put_contents($temp_file, '<?php return null;');
 
@@ -66,16 +65,12 @@ final class ApplicationTraitTest extends UnitTestCase {
   }
 
   public function testApplicationInitWithCustomWorkingDirectory(): void {
-    // Set a custom working directory.
     $this->applicationCwd = self::$tmp;
 
-    // Initialize from command.
     $this->applicationInitFromCommand(GreetingCommand::class);
 
-    // Run a simple command.
     $this->applicationRun([]);
 
-    // Assert the command ran successfully.
     $this->assertApplicationSuccessful();
 
     // Verify custom working directory was used (we can't directly check the
@@ -98,7 +93,6 @@ final class ApplicationTraitTest extends UnitTestCase {
   }
 
   public function testApplicationInitFromCommandWithDefaultName(): void {
-    // Create a command with name set through configuration.
     $command = new class() extends Command {
 
       protected function configure(): void {
@@ -107,20 +101,17 @@ final class ApplicationTraitTest extends UnitTestCase {
 
     };
 
-    // Initialize with this command.
     $this->applicationInitFromCommand($command);
 
     $this->assertInstanceOf(Application::class, $this->application);
     $this->assertInstanceOf(ApplicationTester::class, $this->applicationTester);
 
-    // The application should have the command available.
     $this->assertInstanceOf(Application::class, $this->application);
     $commands = $this->application->all();
     $this->assertArrayHasKey('test:configured-name', $commands);
   }
 
   public function testApplicationInitFromCommandNullName(): void {
-    // Create a command that returns null from getName()
     $command = new class() extends Command {
 
       public function getName(): ?string {
@@ -129,7 +120,7 @@ final class ApplicationTraitTest extends UnitTestCase {
 
     };
 
-    // Symfony's Application class throws this before our null check.
+    // Symfony's Application throws this before the trait's null check.
     $this->expectException(LogicException::class);
     $this->expectExceptionMessage('cannot have an empty name');
 
@@ -137,7 +128,6 @@ final class ApplicationTraitTest extends UnitTestCase {
   }
 
   public function testApplicationInitFromCommandNotSingleCommand(): void {
-    // Test with is_single_command = FALSE.
     $this->applicationInitFromCommand(GreetingCommand::class, FALSE);
 
     $this->assertInstanceOf(Application::class, $this->application);
@@ -157,10 +147,8 @@ final class ApplicationTraitTest extends UnitTestCase {
       throw new \RuntimeException('Fixtures directory is not set.');
     }
 
-    // Set a custom working directory.
     $this->applicationCwd = self::$tmp;
 
-    // Initialize from loader (this will trigger the getcwd check)
     $loader_path = self::$fixtures . '/Application/loader.php';
     $this->applicationInitFromLoader($loader_path);
 
@@ -169,7 +157,6 @@ final class ApplicationTraitTest extends UnitTestCase {
   }
 
   public function testApplicationRunWithShowOutput(): void {
-    // Test that the applicationShowOutput flag can be set.
     $this->applicationShowOutput = TRUE;
     $this->assertTrue($this->applicationShowOutput);
 
@@ -178,21 +165,17 @@ final class ApplicationTraitTest extends UnitTestCase {
 
     $this->applicationInitFromCommand(GreetingCommand::class);
 
-    // The fwrite(STDOUT, ...) call is excluded from coverage, so we can't test
-    // it directly. But we can verify the application runs successfully.
+    // The fwrite(STDOUT, ...) call is excluded from coverage, so it cannot
+    // be tested directly. The test only verifies the application runs
+    // successfully.
     $this->applicationRun(['name' => 'TestUser']);
     $this->assertApplicationSuccessful();
     $this->assertApplicationOutputContains('Hello, TestUser!');
   }
 
-  /**
-   * Test other code paths in applicationTrait.
-   */
   public function testApplicationRunExceptionHandling(): void {
-    // Create an application that will throw an exception from a command.
     $this->application = new Application();
 
-    // Add a command that will throw an Exception (not RuntimeException)
     $command = new class() extends Command {
 
       protected function configure(): void {
@@ -215,7 +198,6 @@ final class ApplicationTraitTest extends UnitTestCase {
     // With expect_fail as true, the exception should be caught.
     $this->applicationRun([], [], TRUE);
 
-    // Without expect_fail, we should get an AssertionFailedError.
     $this->expectException(AssertionFailedError::class);
     $this->applicationRun([]);
   }
@@ -256,9 +238,6 @@ final class ApplicationTraitTest extends UnitTestCase {
     $this->applicationRun([]);
   }
 
-  /**
-   * Test applicationGet() when application is not initialized.
-   */
   public function testApplicationGetNotInitialized(): void {
     $this->expectException(\RuntimeException::class);
     $this->expectExceptionMessage('Application is not initialized. Call applicationInit* first.');
@@ -266,9 +245,6 @@ final class ApplicationTraitTest extends UnitTestCase {
     $this->applicationGet();
   }
 
-  /**
-   * Test applicationGetTester() when tester is not initialized.
-   */
   public function testApplicationGetTesterNotInitialized(): void {
     $this->expectException(\RuntimeException::class);
     $this->expectExceptionMessage('Application tester is not initialized. Call applicationInit* first.');
@@ -276,9 +252,6 @@ final class ApplicationTraitTest extends UnitTestCase {
     $this->applicationGetTester();
   }
 
-  /**
-   * Test applicationGet() when application is initialized.
-   */
   public function testApplicationGetInitialized(): void {
     $this->applicationInitFromCommand(GreetingCommand::class);
 
@@ -287,9 +260,6 @@ final class ApplicationTraitTest extends UnitTestCase {
     $this->assertSame($this->application, $application);
   }
 
-  /**
-   * Test applicationGetTester() when tester is initialized.
-   */
   public function testApplicationGetTesterInitialized(): void {
     $this->applicationInitFromCommand(GreetingCommand::class);
 
@@ -299,7 +269,6 @@ final class ApplicationTraitTest extends UnitTestCase {
   }
 
   public function testApplicationRunWithExpectedFailure(): void {
-    // Create a test command that throws an exception.
     $command = new class() extends Command {
 
       protected function configure(): void {
@@ -317,16 +286,13 @@ final class ApplicationTraitTest extends UnitTestCase {
     // applicationRun() does not throw when expect_fail is TRUE.
     $output = $this->applicationRun([], [], TRUE);
 
-    // The output should contain the error message.
     $this->assertStringContainsString('Test exception message', $output);
 
-    // Try again without expect_fail, which should throw an exception.
     $this->expectException(AssertionFailedError::class);
     $this->applicationRun([]);
   }
 
   public function testApplicationRunWithNonZeroExitCode(): void {
-    // Create a test command that returns a non-zero exit code.
     $command = new class() extends Command {
 
       protected function configure(): void {
@@ -335,7 +301,6 @@ final class ApplicationTraitTest extends UnitTestCase {
 
       protected function execute(InputInterface $input, OutputInterface $output): int {
         $output->writeln('Non-zero exit');
-        // Error exit code.
         return 1;
       }
 
@@ -343,14 +308,11 @@ final class ApplicationTraitTest extends UnitTestCase {
 
     $this->applicationInitFromCommand($command);
 
-    // The applicationRun should throw an exception when the command returns a
-    // non-zero exit code.
     $this->expectException(AssertionFailedError::class);
     $this->applicationRun([]);
   }
 
   public function testApplicationRunWithNonZeroExitCodeAndExpectedFailure(): void {
-    // Create a test command that returns a non-zero exit code.
     $command = new class() extends Command {
 
       protected function configure(): void {
@@ -359,7 +321,6 @@ final class ApplicationTraitTest extends UnitTestCase {
 
       protected function execute(InputInterface $input, OutputInterface $output): int {
         $output->writeln('Non-zero exit');
-        // Error exit code.
         return 1;
       }
 
@@ -371,12 +332,10 @@ final class ApplicationTraitTest extends UnitTestCase {
     // a non-zero exit code but expect_fail is TRUE.
     $output = $this->applicationRun([], [], TRUE);
 
-    // The output should still contain the command output.
     $this->assertStringContainsString('Non-zero exit', $output);
   }
 
   public function testAssertApplicationFailed(): void {
-    // Create a test command that returns a non-zero exit code.
     $command = new class() extends Command {
 
       protected function configure(): void {
@@ -384,41 +343,29 @@ final class ApplicationTraitTest extends UnitTestCase {
       }
 
       protected function execute(InputInterface $input, OutputInterface $output): int {
-        // Error exit code.
         return 1;
       }
 
     };
 
-    // Initialize the application with our test command.
     $this->applicationInitFromCommand($command);
 
-    // Run the command, which will return a non-zero exit code
     // Use expect_fail to prevent an exception.
     $this->applicationRun([], [], TRUE);
 
-    // Now assert that the application actually failed as expected.
     $this->assertApplicationFailed();
   }
 
-  /**
-   * Test that assertApplicationFailed throws an exception for success status.
-   */
   public function testAssertApplicationFailedWithSuccessStatus(): void {
-    // Create a command that succeeds.
     $command = new GreetingCommand();
 
-    // Initialize the application with the command.
     $this->applicationInitFromCommand($command);
 
-    // Run the command to set up the successful status.
     $this->applicationRun([]);
 
-    // Expect the assertion to fail since the application succeeded.
     $this->expectException(ExpectationFailedException::class);
     $this->expectExceptionMessage('Application succeeded when failure was expected');
 
-    // This should fail because the application ran successfully.
     $this->assertApplicationFailed();
   }
 
@@ -429,7 +376,6 @@ final class ApplicationTraitTest extends UnitTestCase {
       $this->markTestSkipped('Could not determine current working directory.');
     }
 
-    // Set a specific working directory for the application.
     $this->applicationCwd = self::$tmp;
 
     if (!self::$fixtures) {
@@ -437,11 +383,9 @@ final class ApplicationTraitTest extends UnitTestCase {
     }
 
     try {
-      // Initialize the application from the loader.
       $loader_path = self::$fixtures . '/Application/loader.php';
       $this->applicationInitFromLoader($loader_path);
 
-      // Assert the application was properly initialized.
       $this->assertInstanceOf(Application::class, $this->application);
       $this->assertInstanceOf(ApplicationTester::class, $this->applicationTester);
 
@@ -472,7 +416,6 @@ final class ApplicationTraitTest extends UnitTestCase {
   }
 
   public function testApplicationErrorOutputAssertions(): void {
-    // Use the dedicated command that generates error output.
     $this->applicationInitFromCommand(ErrorOutputCommand::class);
     $this->applicationRun([]);
 
@@ -590,25 +533,20 @@ final class ApplicationTraitTest extends UnitTestCase {
   }
 
   public function testApplicationAnyOutputErrorCommandAssertions(): void {
-    // Use the dedicated command that generates error output.
     $this->applicationInitFromCommand(ErrorOutputCommand::class);
     $output = $this->applicationRun([]);
 
     $this->assertApplicationSuccessful();
 
-    // Assert that returned output contain expected strings.
     $this->assertStringContainsString('Output message', $output);
     $this->assertStringContainsString('Test Error', $output);
 
-    // Assert that individual output assertions work as expected.
     $this->assertApplicationOutputContains('Output message');
     $this->assertApplicationOutputNotContains('Test Error');
 
-    // Assert that individual error output assertions work as expected.
     $this->assertApplicationErrorOutputNotContains('Output message');
     $this->assertApplicationErrorOutputContains('Test Error');
 
-    // Test that both standard and error output are checked together.
     $this->assertApplicationAnyOutputContainsOrNot([
       '* Test Error',
       '* Output message',
@@ -617,28 +555,23 @@ final class ApplicationTraitTest extends UnitTestCase {
   }
 
   public function testApplicationAnyOutputExceptionCommandAssertions(): void {
-    // Use the dedicated command that generates error output.
     $this->applicationInitFromCommand(ExceptionOutputCommand::class);
     $output = $this->applicationRun([], [], TRUE);
 
     $this->assertApplicationFailed();
 
-    // Assert that returned output contain expected strings.
     $this->assertStringContainsString('Standard output before exception', $output);
     $this->assertStringContainsString('Error output before exception', $output);
     $this->assertStringContainsString('Test exception message', $output);
 
-    // Assert that individual output assertions work as expected.
     $this->assertApplicationOutputContains('Standard output before exception');
     $this->assertApplicationOutputNotContains('Error output before exception');
     $this->assertApplicationOutputNotContains('Test exception message');
 
-    // Assert that individual error output assertions work as expected.
     $this->assertApplicationErrorOutputNotContains('Standard output before exception');
     $this->assertApplicationErrorOutputContains('Error output before exception');
     $this->assertApplicationErrorOutputContains('Test exception message');
 
-    // Assert using the combined output assertion method.
     $this->assertApplicationAnyOutputContainsOrNot([
       'Standard output before exception',
       'Error output before exception',
@@ -683,7 +616,6 @@ final class ApplicationTraitTest extends UnitTestCase {
     $this->expectException(\RuntimeException::class);
     $this->expectExceptionMessage('All strings must have valid prefixes in mixed mode');
 
-    // This should fail - mixed usage (some with prefix, some without)
     $this->assertApplicationOutputContainsOrNot([
       '* Hello',
       'Missing prefix',
@@ -697,7 +629,6 @@ final class ApplicationTraitTest extends UnitTestCase {
     $this->expectException(\RuntimeException::class);
     $this->expectExceptionMessage('All strings must have valid prefixes in mixed mode');
 
-    // This should fail - mixed usage (some with prefix, some without)
     $this->assertApplicationErrorOutputContainsOrNot([
       '* Test Error',
       'Missing prefix',
@@ -724,7 +655,6 @@ final class ApplicationTraitTest extends UnitTestCase {
     $this->expectException(\RuntimeException::class);
     $this->expectExceptionMessage('All strings must have valid prefixes in mixed mode');
 
-    // This should fail - mixed usage (some with prefix, some without)
     $this->assertApplicationAnyOutputContainsOrNot([
       '* Test Error',
       'Missing prefix',
@@ -773,7 +703,6 @@ final class ApplicationTraitTest extends UnitTestCase {
   }
 
   public function testApplicationOutputExactMatchWithMultipleLines(): void {
-    // Create a command that outputs multiple lines.
     $command = new class() extends Command {
 
       protected function configure(): void {

--- a/tests/Unit/AssertArrayTraitTest.php
+++ b/tests/Unit/AssertArrayTraitTest.php
@@ -15,9 +15,6 @@ final class AssertArrayTraitTest extends TestCase {
 
   use AssertArrayTrait;
 
-  /**
-   * Test assertArrayContainsString method.
-   */
   #[DataProvider('dataProviderAssertArrayContainsString')]
   public function testAssertArrayContainsString(string $needle, array $haystack, bool $should_pass, ?string $expected_exception_message = NULL): void {
     if (!$should_pass) {
@@ -34,11 +31,7 @@ final class AssertArrayTraitTest extends TestCase {
     }
   }
 
-  /**
-   * Data provider for assertArrayContainsString tests.
-   */
   public static function dataProviderAssertArrayContainsString(): \Iterator {
-    // Success cases.
     yield 'basic_string_match' => [
       'needle' => 'bar',
       'haystack' => ['foo', 'bar', 'baz'],
@@ -79,7 +72,6 @@ final class AssertArrayTraitTest extends TestCase {
       'haystack' => [0, new \stdClass(), 'test'],
       'should_pass' => TRUE,
     ];
-    // Failure cases.
     yield 'string_not_found' => [
       'needle' => 'xyz',
       'haystack' => ['foo', 'bar', 'baz'],
@@ -99,9 +91,6 @@ final class AssertArrayTraitTest extends TestCase {
     ];
   }
 
-  /**
-   * Test assertArrayNotContainsString method.
-   */
   #[DataProvider('dataProviderAssertArrayNotContainsString')]
   public function testAssertArrayNotContainsString(string $needle, array $haystack, bool $should_pass, ?string $expected_exception_message = NULL): void {
     if (!$should_pass) {
@@ -118,11 +107,7 @@ final class AssertArrayTraitTest extends TestCase {
     }
   }
 
-  /**
-   * Data provider for assertArrayNotContainsString tests.
-   */
   public static function dataProviderAssertArrayNotContainsString(): \Iterator {
-    // Success cases.
     yield 'string_not_found' => [
       'needle' => 'xyz',
       'haystack' => ['foo', 'bar', 'baz'],
@@ -143,7 +128,6 @@ final class AssertArrayTraitTest extends TestCase {
       'haystack' => ['string', new \stdClass(), 123],
       'should_pass' => TRUE,
     ];
-    // Failure cases.
     yield 'string_found' => [
       'needle' => 'ba',
       'haystack' => ['foo', 'bar', 'baz'],
@@ -157,9 +141,6 @@ final class AssertArrayTraitTest extends TestCase {
     ];
   }
 
-  /**
-   * Test assertArrayContainsArray method.
-   */
   #[DataProvider('dataProviderAssertArrayContainsArray')]
   public function testAssertArrayContainsArray(array $array, array $sub_array, bool $should_pass, ?string $expected_exception_message = NULL): void {
     if (!$should_pass) {
@@ -176,11 +157,7 @@ final class AssertArrayTraitTest extends TestCase {
     }
   }
 
-  /**
-   * Data provider for assertArrayContainsArray tests.
-   */
   public static function dataProviderAssertArrayContainsArray(): \Iterator {
-    // Success cases.
     yield 'simple_contains_success' => [
       'array' => ['a', 'b', 'c'],
       'sub_array' => ['a', 'b'],
@@ -253,7 +230,6 @@ final class AssertArrayTraitTest extends TestCase {
       'sub_array' => [['nested', 'target']],
       'should_pass' => TRUE,
     ];
-    // Failure cases.
     yield 'element_not_found_failure' => [
       'array' => ['a', 'b', 'c'],
       'sub_array' => ['d'],
@@ -283,9 +259,6 @@ final class AssertArrayTraitTest extends TestCase {
     ];
   }
 
-  /**
-   * Test assertArrayNotContainsArray method.
-   */
   #[DataProvider('dataProviderAssertArrayNotContainsArray')]
   public function testAssertArrayNotContainsArray(array $array, array $sub_array, bool $should_pass, ?string $expected_exception_message = NULL): void {
     if (!$should_pass) {
@@ -302,11 +275,7 @@ final class AssertArrayTraitTest extends TestCase {
     }
   }
 
-  /**
-   * Data provider for assertArrayNotContainsArray tests.
-   */
   public static function dataProviderAssertArrayNotContainsArray(): \Iterator {
-    // Success cases.
     yield 'element_not_found_success' => [
       'array' => ['a', 'b', 'c'],
       'sub_array' => ['d'],
@@ -345,7 +314,6 @@ final class AssertArrayTraitTest extends TestCase {
       'sub_array' => [['a', 'b', 'c']],
       'should_pass' => TRUE,
     ];
-    // Failure cases.
     yield 'partial_with_missing_failure' => [
       'array' => ['a', 'b'],
       'sub_array' => ['a', 'c'],
@@ -391,9 +359,6 @@ final class AssertArrayTraitTest extends TestCase {
     ];
   }
 
-  /**
-   * Test edge cases and special scenarios.
-   */
   #[DataProvider('dataProviderEdgeCases')]
   public function testEdgeCases(string $method, array $args, bool $should_pass, ?string $expected_exception_message = NULL): void {
     if (!$should_pass) {
@@ -415,13 +380,9 @@ final class AssertArrayTraitTest extends TestCase {
     }
   }
 
-  /**
-   * Data provider for edge cases.
-   */
   public static function dataProviderEdgeCases(): \Iterator {
     $object = new \stdClass();
     $object->property = 'test';
-    // assertArrayContainsArray edge cases.
     yield 'null_values_in_contains' => [
       'method' => 'assertArrayContainsArray',
       'args' => [[NULL, 'a', 'b'], [NULL]],
@@ -455,7 +416,6 @@ final class AssertArrayTraitTest extends TestCase {
       ],
       'should_pass' => TRUE,
     ];
-    // assertArrayNotContainsString with objects.
     yield 'objects_ignored_in_not_contains_string' => [
       'method' => 'assertArrayNotContainsString',
       'args' => ['property', ['string', $object, 123]],
@@ -463,9 +423,6 @@ final class AssertArrayTraitTest extends TestCase {
     ];
   }
 
-  /**
-   * Test custom failure messages work correctly.
-   */
   public function testCustomFailureMessages(): void {
     $custom_message = 'This is a custom failure message';
 

--- a/tests/Unit/AssertArrayTraitTest.php
+++ b/tests/Unit/AssertArrayTraitTest.php
@@ -19,11 +19,11 @@ final class AssertArrayTraitTest extends TestCase {
    * Test assertArrayContainsString method.
    */
   #[DataProvider('dataProviderAssertArrayContainsString')]
-  public function testAssertArrayContainsString(string $needle, array $haystack, bool $should_pass, ?string $expected_exception = NULL): void {
+  public function testAssertArrayContainsString(string $needle, array $haystack, bool $should_pass, ?string $expected_exception_message = NULL): void {
     if (!$should_pass) {
       $this->expectException(AssertionFailedError::class);
-      if ($expected_exception) {
-        $this->expectExceptionMessage($expected_exception);
+      if ($expected_exception_message) {
+        $this->expectExceptionMessage($expected_exception_message);
       }
     }
 
@@ -84,13 +84,13 @@ final class AssertArrayTraitTest extends TestCase {
       'needle' => 'xyz',
       'haystack' => ['foo', 'bar', 'baz'],
       'should_pass' => FALSE,
-      'expected_exception' => 'Failed asserting that string "xyz" is present in array',
+      'expected_exception_message' => 'Failed asserting that string "xyz" is present in array',
     ];
     yield 'empty_array' => [
       'needle' => 'foo',
       'haystack' => [],
       'should_pass' => FALSE,
-      'expected_exception' => 'Failed asserting that string "foo" is present in array',
+      'expected_exception_message' => 'Failed asserting that string "foo" is present in array',
     ];
     yield 'no_partial_match' => [
       'needle' => 'xyz',
@@ -103,11 +103,11 @@ final class AssertArrayTraitTest extends TestCase {
    * Test assertArrayNotContainsString method.
    */
   #[DataProvider('dataProviderAssertArrayNotContainsString')]
-  public function testAssertArrayNotContainsString(string $needle, array $haystack, bool $should_pass, ?string $expected_exception = NULL): void {
+  public function testAssertArrayNotContainsString(string $needle, array $haystack, bool $should_pass, ?string $expected_exception_message = NULL): void {
     if (!$should_pass) {
       $this->expectException(AssertionFailedError::class);
-      if ($expected_exception) {
-        $this->expectExceptionMessage($expected_exception);
+      if ($expected_exception_message) {
+        $this->expectExceptionMessage($expected_exception_message);
       }
     }
 
@@ -148,7 +148,7 @@ final class AssertArrayTraitTest extends TestCase {
       'needle' => 'ba',
       'haystack' => ['foo', 'bar', 'baz'],
       'should_pass' => FALSE,
-      'expected_exception' => 'Failed asserting that string "ba" is not present in array',
+      'expected_exception_message' => 'Failed asserting that string "ba" is not present in array',
     ];
     yield 'partial_match_found' => [
       'needle' => 'oo',
@@ -161,11 +161,11 @@ final class AssertArrayTraitTest extends TestCase {
    * Test assertArrayContainsArray method.
    */
   #[DataProvider('dataProviderAssertArrayContainsArray')]
-  public function testAssertArrayContainsArray(array $array, array $sub_array, bool $should_pass, ?string $expected_exception = NULL): void {
+  public function testAssertArrayContainsArray(array $array, array $sub_array, bool $should_pass, ?string $expected_exception_message = NULL): void {
     if (!$should_pass) {
       $this->expectException(AssertionFailedError::class);
-      if ($expected_exception) {
-        $this->expectExceptionMessage($expected_exception);
+      if ($expected_exception_message) {
+        $this->expectExceptionMessage($expected_exception_message);
       }
     }
 
@@ -258,7 +258,7 @@ final class AssertArrayTraitTest extends TestCase {
       'array' => ['a', 'b', 'c'],
       'sub_array' => ['d'],
       'should_pass' => FALSE,
-      'expected_exception' => "Value 'd' not found in array",
+      'expected_exception_message' => "Value 'd' not found in array",
     ];
     yield 'partial_match_failure' => [
       'array' => ['a', 'b', 'c'],
@@ -272,7 +272,7 @@ final class AssertArrayTraitTest extends TestCase {
       ],
       'sub_array' => [['a', 'b']],
       'should_pass' => FALSE,
-      'expected_exception' => 'Expected sub-array not found',
+      'expected_exception_message' => 'Expected sub-array not found',
     ];
     yield 'different_order_failure' => [
       'array' => [
@@ -287,11 +287,11 @@ final class AssertArrayTraitTest extends TestCase {
    * Test assertArrayNotContainsArray method.
    */
   #[DataProvider('dataProviderAssertArrayNotContainsArray')]
-  public function testAssertArrayNotContainsArray(array $array, array $sub_array, bool $should_pass, ?string $expected_exception = NULL): void {
+  public function testAssertArrayNotContainsArray(array $array, array $sub_array, bool $should_pass, ?string $expected_exception_message = NULL): void {
     if (!$should_pass) {
       $this->expectException(AssertionFailedError::class);
-      if ($expected_exception) {
-        $this->expectExceptionMessage($expected_exception);
+      if ($expected_exception_message) {
+        $this->expectExceptionMessage($expected_exception_message);
       }
     }
 
@@ -350,7 +350,7 @@ final class AssertArrayTraitTest extends TestCase {
       'array' => ['a', 'b'],
       'sub_array' => ['a', 'c'],
       'should_pass' => FALSE,
-      'expected_exception' => "Unexpected value 'a' found in array",
+      'expected_exception_message' => "Unexpected value 'a' found in array",
     ];
     yield 'simple_contains_failure' => [
       'array' => ['a', 'b', 'c'],
@@ -369,13 +369,13 @@ final class AssertArrayTraitTest extends TestCase {
       ],
       'sub_array' => [['name' => 'John', 'age' => 30]],
       'should_pass' => FALSE,
-      'expected_exception' => 'Unexpected sub-array found',
+      'expected_exception_message' => 'Unexpected sub-array found',
     ];
     yield 'empty_subarray_failure' => [
       'array' => ['a', 'b', 'c'],
       'sub_array' => [],
       'should_pass' => FALSE,
-      'expected_exception' => 'Empty sub-array is a subset of any non-empty array',
+      'expected_exception_message' => 'Empty sub-array is a subset of any non-empty array',
     ];
     yield 'recursive_match_failure' => [
       'array' => [
@@ -387,7 +387,7 @@ final class AssertArrayTraitTest extends TestCase {
       ],
       'sub_array' => [['target', 'found']],
       'should_pass' => FALSE,
-      'expected_exception' => 'Unexpected sub-array found',
+      'expected_exception_message' => 'Unexpected sub-array found',
     ];
   }
 
@@ -395,11 +395,11 @@ final class AssertArrayTraitTest extends TestCase {
    * Test edge cases and special scenarios.
    */
   #[DataProvider('dataProviderEdgeCases')]
-  public function testEdgeCases(string $method, array $args, bool $should_pass, ?string $expected_exception = NULL): void {
+  public function testEdgeCases(string $method, array $args, bool $should_pass, ?string $expected_exception_message = NULL): void {
     if (!$should_pass) {
       $this->expectException(AssertionFailedError::class);
-      if ($expected_exception) {
-        $this->expectExceptionMessage($expected_exception);
+      if ($expected_exception_message) {
+        $this->expectExceptionMessage($expected_exception_message);
       }
     }
 

--- a/tests/Unit/EnvTraitTest.php
+++ b/tests/Unit/EnvTraitTest.php
@@ -29,7 +29,7 @@ final class EnvTraitTest extends TestCase {
 
     self::envSet($name, $value);
 
-    $this->assertEquals($value, self::envGet($name));
+    $this->assertSame($value, self::envGet($name));
     $this->assertTrue(self::envIsSet($name));
     $this->assertFalse(self::envIsUnset($name));
   }
@@ -44,7 +44,7 @@ final class EnvTraitTest extends TestCase {
     self::envSetMultiple($vars);
 
     foreach ($vars as $name => $value) {
-      $this->assertEquals($value, self::envGet($name));
+      $this->assertSame($value, self::envGet($name));
       $this->assertTrue(self::envIsSet($name));
     }
   }
@@ -142,8 +142,8 @@ final class EnvTraitTest extends TestCase {
 
     self::envFromInput($input, 'TEST_PREFIX_');
 
-    $this->assertEquals('value1', self::envGet('TEST_PREFIX_VAR1'));
-    $this->assertEquals('value2', self::envGet('TEST_PREFIX_VAR2'));
+    $this->assertSame('value1', self::envGet('TEST_PREFIX_VAR1'));
+    $this->assertSame('value2', self::envGet('TEST_PREFIX_VAR2'));
     $this->assertFalse(self::envIsSet('OTHER_VAR'));
     $this->assertArrayNotHasKey('TEST_PREFIX_VAR1', $input);
     $this->assertArrayNotHasKey('TEST_PREFIX_VAR2', $input);
@@ -154,8 +154,8 @@ final class EnvTraitTest extends TestCase {
 
     self::envFromInput($input, 'TEST_PREFIX_', FALSE);
 
-    $this->assertEquals('value1', self::envGet('TEST_PREFIX_VAR1'));
-    $this->assertEquals('value2', self::envGet('TEST_PREFIX_VAR2'));
+    $this->assertSame('value1', self::envGet('TEST_PREFIX_VAR1'));
+    $this->assertSame('value2', self::envGet('TEST_PREFIX_VAR2'));
     $this->assertArrayHasKey('TEST_PREFIX_VAR1', $input);
     $this->assertArrayHasKey('TEST_PREFIX_VAR2', $input);
     $this->assertArrayHasKey('OTHER_VAR', $input);

--- a/tests/Unit/EnvTraitTest.php
+++ b/tests/Unit/EnvTraitTest.php
@@ -15,11 +15,11 @@ final class EnvTraitTest extends TestCase {
 
   protected function setUp(): void {
     parent::setUp();
-    $this->envReset();
+    self::envReset();
   }
 
   protected function tearDown(): void {
-    $this->envReset();
+    self::envReset();
     parent::tearDown();
   }
 
@@ -27,11 +27,11 @@ final class EnvTraitTest extends TestCase {
     $name = 'TEST_ENV_VAR';
     $value = 'test_value';
 
-    $this->envSet($name, $value);
+    self::envSet($name, $value);
 
-    $this->assertEquals($value, $this->envGet($name));
-    $this->assertTrue($this->envIsSet($name));
-    $this->assertFalse($this->envIsUnset($name));
+    $this->assertEquals($value, self::envGet($name));
+    $this->assertTrue(self::envIsSet($name));
+    $this->assertFalse(self::envIsUnset($name));
   }
 
   public function testEnvSetMultiple(): void {
@@ -41,11 +41,11 @@ final class EnvTraitTest extends TestCase {
       'TEST_ENV_VAR3' => 'value3',
     ];
 
-    $this->envSetMultiple($vars);
+    self::envSetMultiple($vars);
 
     foreach ($vars as $name => $value) {
-      $this->assertEquals($value, $this->envGet($name));
-      $this->assertTrue($this->envIsSet($name));
+      $this->assertEquals($value, self::envGet($name));
+      $this->assertTrue(self::envIsSet($name));
     }
   }
 
@@ -53,13 +53,13 @@ final class EnvTraitTest extends TestCase {
     $name = 'TEST_ENV_VAR';
     $value = 'test_value';
 
-    $this->envSet($name, $value);
-    $this->assertTrue($this->envIsSet($name));
+    self::envSet($name, $value);
+    $this->assertTrue(self::envIsSet($name));
 
-    $this->envUnset($name);
+    self::envUnset($name);
 
-    $this->assertFalse($this->envIsSet($name));
-    $this->assertTrue($this->envIsUnset($name));
+    $this->assertFalse(self::envIsSet($name));
+    $this->assertTrue(self::envIsUnset($name));
   }
 
   public function testEnvUnsetMultiple(): void {
@@ -70,18 +70,18 @@ final class EnvTraitTest extends TestCase {
       'TEST_ENV_VAR4' => 'value4',
     ];
 
-    $this->envSetMultiple($vars);
+    self::envSetMultiple($vars);
 
     foreach (array_keys($vars) as $name) {
-      $this->assertTrue($this->envIsSet($name));
+      $this->assertTrue(self::envIsSet($name));
     }
 
-    $this->envUnsetMultiple(['TEST_ENV_VAR1', 'TEST_ENV_VAR2', 'TEST_ENV_VAR3']);
+    self::envUnsetMultiple(['TEST_ENV_VAR1', 'TEST_ENV_VAR2', 'TEST_ENV_VAR3']);
 
-    $this->assertFalse($this->envIsSet('TEST_ENV_VAR1'));
-    $this->assertFalse($this->envIsSet('TEST_ENV_VAR2'));
-    $this->assertFalse($this->envIsSet('TEST_ENV_VAR3'));
-    $this->assertTrue($this->envIsSet('TEST_ENV_VAR4'));
+    $this->assertFalse(self::envIsSet('TEST_ENV_VAR1'));
+    $this->assertFalse(self::envIsSet('TEST_ENV_VAR2'));
+    $this->assertFalse(self::envIsSet('TEST_ENV_VAR3'));
+    $this->assertTrue(self::envIsSet('TEST_ENV_VAR4'));
   }
 
   public function testEnvUnsetPrefix(): void {
@@ -91,23 +91,23 @@ final class EnvTraitTest extends TestCase {
       'OTHER_VAR' => 'value3',
     ];
 
-    $this->envSetMultiple($vars);
+    self::envSetMultiple($vars);
 
-    $this->envUnsetPrefix('TEST_PREFIX_');
+    self::envUnsetPrefix('TEST_PREFIX_');
 
-    $this->assertFalse($this->envIsSet('TEST_PREFIX_VAR1'));
-    $this->assertFalse($this->envIsSet('TEST_PREFIX_VAR2'));
-    $this->assertTrue($this->envIsSet('OTHER_VAR'));
+    $this->assertFalse(self::envIsSet('TEST_PREFIX_VAR1'));
+    $this->assertFalse(self::envIsSet('TEST_PREFIX_VAR2'));
+    $this->assertTrue(self::envIsSet('OTHER_VAR'));
   }
 
   public function testEnvUnsetPrefixWithSystemEnv(): void {
-    $this->envReset();
+    self::envReset();
     putenv('TEST_SYS_PREFIX_VAR=test_value');
-    $this->assertTrue($this->envIsSet('TEST_SYS_PREFIX_VAR'));
+    $this->assertTrue(self::envIsSet('TEST_SYS_PREFIX_VAR'));
 
-    $this->envUnsetPrefix('TEST_SYS_PREFIX_');
+    self::envUnsetPrefix('TEST_SYS_PREFIX_');
 
-    $this->assertFalse($this->envIsSet('TEST_SYS_PREFIX_VAR'));
+    $this->assertFalse(self::envIsSet('TEST_SYS_PREFIX_VAR'));
     putenv('TEST_SYS_PREFIX_VAR');
   }
 
@@ -118,16 +118,16 @@ final class EnvTraitTest extends TestCase {
       'TEST_ENV_VAR3' => 'value3',
     ];
 
-    $this->envSetMultiple($vars);
+    self::envSetMultiple($vars);
 
     foreach (array_keys($vars) as $name) {
-      $this->assertTrue($this->envIsSet($name));
+      $this->assertTrue(self::envIsSet($name));
     }
 
-    $this->envReset();
+    self::envReset();
 
     foreach (array_keys($vars) as $name) {
-      $this->assertFalse($this->envIsSet($name));
+      $this->assertFalse(self::envIsSet($name));
     }
   }
 
@@ -140,22 +140,22 @@ final class EnvTraitTest extends TestCase {
 
     $input_copy = $input;
 
-    $this->envFromInput($input, 'TEST_PREFIX_');
+    self::envFromInput($input, 'TEST_PREFIX_');
 
-    $this->assertEquals('value1', $this->envGet('TEST_PREFIX_VAR1'));
-    $this->assertEquals('value2', $this->envGet('TEST_PREFIX_VAR2'));
-    $this->assertFalse($this->envIsSet('OTHER_VAR'));
+    $this->assertEquals('value1', self::envGet('TEST_PREFIX_VAR1'));
+    $this->assertEquals('value2', self::envGet('TEST_PREFIX_VAR2'));
+    $this->assertFalse(self::envIsSet('OTHER_VAR'));
     $this->assertArrayNotHasKey('TEST_PREFIX_VAR1', $input);
     $this->assertArrayNotHasKey('TEST_PREFIX_VAR2', $input);
     $this->assertArrayHasKey('OTHER_VAR', $input);
 
-    $this->envReset();
+    self::envReset();
     $input = $input_copy;
 
-    $this->envFromInput($input, 'TEST_PREFIX_', FALSE);
+    self::envFromInput($input, 'TEST_PREFIX_', FALSE);
 
-    $this->assertEquals('value1', $this->envGet('TEST_PREFIX_VAR1'));
-    $this->assertEquals('value2', $this->envGet('TEST_PREFIX_VAR2'));
+    $this->assertEquals('value1', self::envGet('TEST_PREFIX_VAR1'));
+    $this->assertEquals('value2', self::envGet('TEST_PREFIX_VAR2'));
     $this->assertArrayHasKey('TEST_PREFIX_VAR1', $input);
     $this->assertArrayHasKey('TEST_PREFIX_VAR2', $input);
     $this->assertArrayHasKey('OTHER_VAR', $input);

--- a/tests/Unit/LocationsTraitTest.php
+++ b/tests/Unit/LocationsTraitTest.php
@@ -431,7 +431,7 @@ class LocationsTraitTest extends TestCase {
     ];
   }
 
-  public function testLocationGetters(): void {
+  public function testLocationsGetters(): void {
     $this->locationsInit($this->testCwd);
 
     // Test all getter methods return the same values as direct property access.
@@ -490,7 +490,7 @@ class LocationsTraitTest extends TestCase {
     $this->assertDirectoryDoesNotExist(self::$workspace);
   }
 
-  public function testLocationsFixtureDirThrowsExceptionWhenFixturesDirectoryMissing(): void {
+  public function testLocationsFixtureDirThrowsExceptionWhenFixturesDirMissing(): void {
     // Create a temporary directory without fixtures subdirectory.
     $test_cwd_no_fixtures = sys_get_temp_dir() . DIRECTORY_SEPARATOR . uniqid('locations_trait_test_no_fixtures_dir_', TRUE);
     mkdir($test_cwd_no_fixtures, 0777, TRUE);

--- a/tests/Unit/LocationsTraitTest.php
+++ b/tests/Unit/LocationsTraitTest.php
@@ -22,6 +22,8 @@ class LocationsTraitTest extends TestCase {
   protected string $testFixtures;
 
   protected function setUp(): void {
+    parent::setUp();
+
     $this->testTmp = sys_get_temp_dir() . DIRECTORY_SEPARATOR . uniqid('locations_trait_test_tmp_', TRUE);
     mkdir($this->testTmp, 0777, TRUE);
 
@@ -42,6 +44,8 @@ class LocationsTraitTest extends TestCase {
     if (is_dir($this->testFixtures)) {
       rmdir($this->testFixtures);
     }
+
+    parent::tearDown();
   }
 
   public function testLocationsInit(): void {

--- a/tests/Unit/LocationsTraitTest.php
+++ b/tests/Unit/LocationsTraitTest.php
@@ -107,7 +107,6 @@ class LocationsTraitTest extends TestCase {
       $this->assertDirectoryExists(self::$tmp);
     }
     finally {
-      // Restore original working directory.
       chdir($original_cwd);
     }
   }
@@ -126,7 +125,6 @@ class LocationsTraitTest extends TestCase {
     self::$fixtures = NULL;
 
     try {
-      // Change to the test directory.
       chdir($test_cwd_no_fixtures);
 
       $mock = $this->createPartialMock(self::class, ['locationsFixturesDir']);
@@ -140,7 +138,6 @@ class LocationsTraitTest extends TestCase {
       $this->assertNull(self::$fixtures, 'Fixtures property should be null when directory does not exist.');
     }
     finally {
-      // Restore original state.
       self::$fixtures = $original_fixtures;
       chdir($original_cwd);
 
@@ -210,7 +207,6 @@ class LocationsTraitTest extends TestCase {
     file_put_contents($file1, 'Test file 1');
     file_put_contents($file2, 'Test file 2');
 
-    // Test with default parameters.
     $files = [$file1, $file2];
     $copied_files = self::locationsCopyFilesToSut($files);
 
@@ -232,7 +228,6 @@ class LocationsTraitTest extends TestCase {
   }
 
   public function testLocationsTearDown(): void {
-    // Create a workspace directory with some content to test removal.
     self::$workspace = $this->testTmp . DIRECTORY_SEPARATOR . 'test_workspace_' . uniqid();
     mkdir(self::$workspace, 0777, TRUE);
     touch(self::$workspace . DIRECTORY_SEPARATOR . 'test_file.txt');
@@ -241,27 +236,19 @@ class LocationsTraitTest extends TestCase {
   }
 
   public function testLocationsTearDownWithRestrictedPermissions(): void {
-    // Create a workspace directory with restricted permissions to test chmod
-    // handling.
     self::$workspace = $this->testTmp . DIRECTORY_SEPARATOR . 'test_workspace_restricted_' . uniqid();
     mkdir(self::$workspace, 0777, TRUE);
 
-    // Create a subdirectory structure with files.
     $subdir = self::$workspace . DIRECTORY_SEPARATOR . 'subdir';
     mkdir($subdir, 0777, TRUE);
     touch($subdir . DIRECTORY_SEPARATOR . 'test_file.txt');
 
-    // Make the subdirectory read-only to simulate permission issues.
     chmod($subdir, 0555);
 
-    // Verify the directory is read-only.
     $this->assertIsNotWritable($subdir, 'Subdirectory should be read-only.');
 
-    // locationsTearDown should handle the chmod and remove the directory
-    // successfully.
     $this->locationsTearDown();
 
-    // Verify the workspace was completely removed.
     $this->assertDirectoryDoesNotExist(self::$workspace, 'Workspace with restricted permissions should be removed.');
   }
 
@@ -432,7 +419,6 @@ class LocationsTraitTest extends TestCase {
   public function testLocationsGetters(): void {
     $this->locationsInit($this->testCwd);
 
-    // Test all getter methods return the same values as direct property access.
     $this->assertSame(self::$root, self::locationsRoot());
     $this->assertSame(self::$fixtures, self::locationsFixtures());
     $this->assertSame(self::$workspace, self::locationsWorkspace());
@@ -440,39 +426,29 @@ class LocationsTraitTest extends TestCase {
     $this->assertSame(self::$sut, self::locationsSut());
     $this->assertSame(self::$tmp, self::locationsTmp());
 
-    // Test that getters return expected directory types.
     $this->assertDirectoryExists(self::locationsRoot());
     $this->assertDirectoryExists(self::locationsWorkspace());
     $this->assertDirectoryExists(self::locationsRepo());
     $this->assertDirectoryExists(self::locationsSut());
     $this->assertDirectoryExists(self::locationsTmp());
 
-    // Test fixtures getter specifically (can be null)
     if (self::locationsFixtures() !== NULL) {
       $this->assertDirectoryExists(self::locationsFixtures());
     }
   }
 
   public function testLocationsTearDownWithChmodException(): void {
-    // Create a workspace directory with restricted permissions to simulate
-    // chmod issues.
     self::$workspace = $this->testTmp . DIRECTORY_SEPARATOR . 'test_workspace_chmod_fail_' . uniqid();
     mkdir(self::$workspace, 0777, TRUE);
 
-    // Create a subdirectory and file structure that might cause chmod issues.
     $subdir = self::$workspace . DIRECTORY_SEPARATOR . 'readonly_subdir';
     mkdir($subdir, 0777, TRUE);
     touch($subdir . DIRECTORY_SEPARATOR . 'test_file.txt');
 
-    // Make the subdirectory read-only to potentially trigger chmod issues
-    // when locationsTearDown tries to modify permissions.
     chmod($subdir, 0444);
 
-    // Test that locationsTearDown completes successfully even if chmod fails.
-    // This tests the exception handling path in the actual implementation.
     $this->locationsTearDown();
 
-    // Verify the workspace was removed despite potential chmod exceptions.
     $this->assertDirectoryDoesNotExist(self::$workspace, 'Workspace should be removed even with chmod exception.');
   }
 
@@ -489,7 +465,6 @@ class LocationsTraitTest extends TestCase {
   }
 
   public function testLocationsFixtureDirThrowsExceptionWhenFixturesDirMissing(): void {
-    // Create a temporary directory without fixtures subdirectory.
     $test_cwd_no_fixtures = sys_get_temp_dir() . DIRECTORY_SEPARATOR . uniqid('locations_trait_test_no_fixtures_dir_', TRUE);
     mkdir($test_cwd_no_fixtures, 0777, TRUE);
 
@@ -514,7 +489,6 @@ class LocationsTraitTest extends TestCase {
     /** @var non-empty-string $expected_suffix */
     $this->locationsInit($this->testCwd);
 
-    // Create dataset directory structure for each test case.
     $dataset_dir = $this->testFixtures . DIRECTORY_SEPARATOR . 'locations_fixture_dir_with_baseline_dataset' . DIRECTORY_SEPARATOR . $expected_suffix;
     mkdir($dataset_dir, 0777, TRUE);
     touch($dataset_dir . DIRECTORY_SEPARATOR . 'test_file.txt');
@@ -541,16 +515,13 @@ class LocationsTraitTest extends TestCase {
     $dest_dir = $this->testTmp . DIRECTORY_SEPARATOR . 'copy_dest_nonexistent_' . uniqid();
     mkdir($dest_dir, 0777, TRUE);
 
-    // Create one existing file.
     $existing_file = $source_dir . DIRECTORY_SEPARATOR . 'existing.txt';
     file_put_contents($existing_file, 'content');
 
-    // Try to include a non-existent file along with the existing one.
     $include_files = [$existing_file, $source_dir . DIRECTORY_SEPARATOR . 'nonexistent.txt'];
 
     $result = self::locationsCopy($source_dir, $dest_dir, $include_files);
 
-    // Should only copy the existing file.
     $this->assertCount(1, $result);
     $this->assertFileExists($result[0]);
 

--- a/tests/Unit/LocationsTraitTest.php
+++ b/tests/Unit/LocationsTraitTest.php
@@ -262,13 +262,7 @@ class LocationsTraitTest extends TestCase {
   }
 
   #[DataProvider('dataProviderLocationsCopy')]
-  public function testLocationsCopy(
-    array $source_files,
-    array $include_files,
-    array $exclude_dirs,
-    bool $use_before_callback,
-    int $expected_count,
-  ): void {
+  public function testLocationsCopy(array $source_files, array $include_files, array $exclude_dirs, bool $use_before_callback, int $expected_count): void {
     $this->locationsInit($this->testCwd);
 
     $source_dir = $this->testTmp . DIRECTORY_SEPARATOR . 'copy_source_' . uniqid();

--- a/tests/Unit/LoggerTraitTest.php
+++ b/tests/Unit/LoggerTraitTest.php
@@ -492,9 +492,6 @@ final class LoggerTraitTest extends UnitTestCase {
     self::logStepFinish('Silent step end');
 
     $silent_output = $this->getCapturedOutput();
-    if (!empty($silent_output)) {
-      echo "DEBUG: Unexpected output: " . json_encode($silent_output) . "\n";
-    }
     $this->assertEmpty($silent_output);
 
     // Reset buffer and steps tracking, then test with verbose enabled.
@@ -1102,7 +1099,6 @@ final class LoggerTraitTest extends UnitTestCase {
 
     $result = self::logStepSummary();
 
-    $this->addToAssertionCount(1);
     $this->assertStringContainsString('testLogStepSummaryReturn', $result);
     $this->assertStringContainsString('Complete', $result);
   }

--- a/tests/Unit/LoggerTraitTest.php
+++ b/tests/Unit/LoggerTraitTest.php
@@ -604,7 +604,7 @@ final class LoggerTraitTest extends UnitTestCase {
     $method = $reflection_class->getMethod('formatElapsedTime');
 
     $result = $method->invoke(NULL, $input_seconds);
-    $this->assertEquals($expected_output, $result);
+    $this->assertSame($expected_output, $result);
   }
 
   /**
@@ -733,7 +733,7 @@ final class LoggerTraitTest extends UnitTestCase {
     $this->assertIsArray($steps);
     $this->assertCount(1, $steps);
     // @phpstan-ignore-next-line offsetAccess.nonOffsetAccessible
-    $this->assertEquals('testStepArrayTracking', $steps[0]['name']);
+    $this->assertSame('testStepArrayTracking', $steps[0]['name']);
     // @phpstan-ignore-next-line offsetAccess.nonOffsetAccessible
     $this->assertNull($steps[0]['end_time']);
 
@@ -752,7 +752,7 @@ final class LoggerTraitTest extends UnitTestCase {
     $this->assertIsArray($steps);
     $this->assertCount(2, $steps);
     // @phpstan-ignore-next-line offsetAccess.nonOffsetAccessible
-    $this->assertEquals('testStepArrayTracking', $steps[1]['name']);
+    $this->assertSame('testStepArrayTracking', $steps[1]['name']);
   }
 
   /**
@@ -772,7 +772,7 @@ final class LoggerTraitTest extends UnitTestCase {
 
     rewind($custom_buffer);
     $output = stream_get_contents($custom_buffer);
-    $this->assertEquals("\nCustom stream test\n", $output);
+    $this->assertSame("\nCustom stream test\n", $output);
 
     fclose($custom_buffer);
   }
@@ -791,7 +791,7 @@ final class LoggerTraitTest extends UnitTestCase {
     $method = $reflection_class->getMethod('getOutputStream');
 
     $stream = $method->invoke(NULL);
-    $this->assertEquals(STDERR, $stream);
+    $this->assertSame(STDERR, $stream);
   }
 
   /**
@@ -847,7 +847,7 @@ final class LoggerTraitTest extends UnitTestCase {
     $method = $reflection_class->getMethod('getOutputStream');
 
     $stream = $method->invoke(NULL);
-    $this->assertEquals($valid_resource, $stream);
+    $this->assertSame($valid_resource, $stream);
 
     fclose($valid_resource);
   }
@@ -1020,7 +1020,7 @@ final class LoggerTraitTest extends UnitTestCase {
     $this->assertCount(1, $steps);
     // @phpstan-ignore-next-line offsetAccess.nonOffsetAccessible
     $this->assertEmpty($steps[0]['parent_stack']);
-    $this->assertEquals(['testHierarchicalStepTracking'], $stack);
+    $this->assertSame(['testHierarchicalStepTracking'], $stack);
 
     // Start nested step.
     self::logStepStart('Level 2');
@@ -1030,8 +1030,8 @@ final class LoggerTraitTest extends UnitTestCase {
     // @phpstan-ignore-next-line argument.type
     $this->assertCount(2, $steps);
     // @phpstan-ignore-next-line offsetAccess.nonOffsetAccessible
-    $this->assertEquals(['testHierarchicalStepTracking'], $steps[1]['parent_stack']);
-    $this->assertEquals(['testHierarchicalStepTracking', 'testHierarchicalStepTracking'], $stack);
+    $this->assertSame(['testHierarchicalStepTracking'], $steps[1]['parent_stack']);
+    $this->assertSame(['testHierarchicalStepTracking', 'testHierarchicalStepTracking'], $stack);
 
     // Start deeply nested step.
     self::logStepStart('Level 3');
@@ -1041,18 +1041,18 @@ final class LoggerTraitTest extends UnitTestCase {
     // @phpstan-ignore-next-line argument.type
     $this->assertCount(3, $steps);
     // @phpstan-ignore-next-line offsetAccess.nonOffsetAccessible
-    $this->assertEquals(['testHierarchicalStepTracking', 'testHierarchicalStepTracking'], $steps[2]['parent_stack']);
-    $this->assertEquals(['testHierarchicalStepTracking', 'testHierarchicalStepTracking', 'testHierarchicalStepTracking'], $stack);
+    $this->assertSame(['testHierarchicalStepTracking', 'testHierarchicalStepTracking'], $steps[2]['parent_stack']);
+    $this->assertSame(['testHierarchicalStepTracking', 'testHierarchicalStepTracking', 'testHierarchicalStepTracking'], $stack);
 
     // Finish level 3.
     self::logStepFinish('Level 3 done');
     $stack = $stack_property->getValue();
-    $this->assertEquals(['testHierarchicalStepTracking', 'testHierarchicalStepTracking'], $stack);
+    $this->assertSame(['testHierarchicalStepTracking', 'testHierarchicalStepTracking'], $stack);
 
     // Finish level 2.
     self::logStepFinish('Level 2 done');
     $stack = $stack_property->getValue();
-    $this->assertEquals(['testHierarchicalStepTracking'], $stack);
+    $this->assertSame(['testHierarchicalStepTracking'], $stack);
 
     // Finish level 1.
     self::logStepFinish('Level 1 done');

--- a/tests/Unit/LoggerTraitTest.php
+++ b/tests/Unit/LoggerTraitTest.php
@@ -599,12 +599,12 @@ final class LoggerTraitTest extends UnitTestCase {
    * Test formatElapsedTime method with various durations.
    */
   #[DataProvider('dataProviderFormatElapsedTime')]
-  public function testFormatElapsedTime(float $inputSeconds, string $expectedOutput): void {
+  public function testFormatElapsedTime(float $input_seconds, string $expected_output): void {
     $reflection_class = new \ReflectionClass(self::class);
     $method = $reflection_class->getMethod('formatElapsedTime');
 
-    $result = $method->invoke(NULL, $inputSeconds);
-    $this->assertEquals($expectedOutput, $result);
+    $result = $method->invoke(NULL, $input_seconds);
+    $this->assertEquals($expected_output, $result);
   }
 
   /**
@@ -870,14 +870,14 @@ final class LoggerTraitTest extends UnitTestCase {
    * Test various logger methods in verbose and silent modes.
    */
   #[DataProvider('dataProviderLoggerMethodsVerboseMode')]
-  public function testLoggerMethodsVerboseMode(bool $verboseMode, string $description, callable $testMethod): void {
-    self::loggerSetVerbose($verboseMode);
+  public function testLoggerMethodsVerboseMode(bool $verbose_mode, string $description, callable $test_method): void {
+    self::loggerSetVerbose($verbose_mode);
 
-    $testMethod(self::class);
+    $test_method(self::class);
 
     $output = $this->getCapturedOutput();
 
-    if ($verboseMode) {
+    if ($verbose_mode) {
       $this->assertNotEmpty($output, sprintf('Expected output for %s in verbose mode', $description));
     }
     else {
@@ -907,14 +907,14 @@ final class LoggerTraitTest extends UnitTestCase {
   /**
    * Test step methods with various parameters.
    *
-   * @param array<string> $expectedOutput
+   * @param array<string> $expected_output
    */
   #[DataProvider('dataProviderStepMethods')]
-  public function testStepMethods(string $stepName, ?string $message, array $expectedOutput): void {
+  public function testStepMethods(string $step_name, ?string $message, array $expected_output): void {
     self::loggerSetVerbose(TRUE);
 
     // Test both start and finish for completeness.
-    if (str_contains($expectedOutput[0], 'START')) {
+    if (str_contains($expected_output[0], 'START')) {
       self::logStepStart($message);
     }
     else {
@@ -925,7 +925,7 @@ final class LoggerTraitTest extends UnitTestCase {
 
     $output = $this->getCapturedOutput();
 
-    foreach ($expectedOutput as $expected_string) {
+    foreach ($expected_output as $expected_string) {
       $this->assertStringContainsString($expected_string, $output, sprintf("Expected to find '%s' in output", $expected_string));
     }
   }
@@ -946,10 +946,10 @@ final class LoggerTraitTest extends UnitTestCase {
   /**
    * Test section formatting with various parameters.
    *
-   * @param array<string> $expectedStrings
+   * @param array<string> $expected_strings
    */
   #[DataProvider('dataProviderSectionFormatting')]
-  public function testSectionFormatting(string $title, ?string $message, bool $doubleBorder, int $minWidth, array $expectedStrings): void {
+  public function testSectionFormatting(string $title, ?string $message, bool $double_border, int $min_width, array $expected_strings): void {
     self::loggerSetVerbose(TRUE);
 
     // Reset buffer for each test case.
@@ -960,10 +960,10 @@ final class LoggerTraitTest extends UnitTestCase {
     $this->logBuffer = $buffer;
     self::loggerSetOutputStream($this->logBuffer);
 
-    self::logSection($title, $message, $doubleBorder, $minWidth);
+    self::logSection($title, $message, $double_border, $min_width);
 
     $output = $this->getCapturedOutput();
-    foreach ($expectedStrings as $expected_string) {
+    foreach ($expected_strings as $expected_string) {
       $this->assertStringContainsString($expected_string, $output, 'Failed for title: ' . $title);
     }
   }
@@ -972,7 +972,7 @@ final class LoggerTraitTest extends UnitTestCase {
    * Provides test data for section formatting.
    *
    * @return \Iterator<string, array{string, (string | null), bool, int, array<string>}>
-   *   Test cases: [title, message, doubleBorder, minWidth, expectedStrings]
+   *   Test cases: [title, message, double_border, min_width, expected_strings]
    */
   public static function dataProviderSectionFormatting(): \Iterator {
     yield 'basic title only' => ['BASIC TITLE', NULL, FALSE, 60, ['BASIC TITLE', '---']];

--- a/tests/Unit/LoggerTraitTest.php
+++ b/tests/Unit/LoggerTraitTest.php
@@ -4,11 +4,11 @@ declare(strict_types=1);
 
 namespace AlexSkrypnyk\PhpunitHelpers\Tests\Unit;
 
-use PHPUnit\Framework\Attributes\DoesNotPerformAssertions;
 use AlexSkrypnyk\PhpunitHelpers\Traits\LoggerTrait;
 use AlexSkrypnyk\PhpunitHelpers\UnitTestCase;
 use PHPUnit\Framework\Attributes\CoversTrait;
 use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\DoesNotPerformAssertions;
 
 /**
  * Tests for LoggerTrait.

--- a/tests/Unit/LoggerTraitTest.php
+++ b/tests/Unit/LoggerTraitTest.php
@@ -933,7 +933,7 @@ final class LoggerTraitTest extends UnitTestCase {
   /**
    * Provides test data for step method workflow testing.
    *
-   * @return \Iterator<string, array{string, (string | null), array<string>}>
+   * @return \Iterator<string, array{string, (string|null), array<string>}>
    *   Test cases: [step_name, message, expected_output_contains]
    */
   public static function dataProviderStepMethods(): \Iterator {
@@ -971,7 +971,7 @@ final class LoggerTraitTest extends UnitTestCase {
   /**
    * Provides test data for section formatting.
    *
-   * @return \Iterator<string, array{string, (string | null), bool, int, array<string>}>
+   * @return \Iterator<string, array{string, (string|null), bool, int, array<string>}>
    *   Test cases: [title, message, double_border, min_width, expected_strings]
    */
   public static function dataProviderSectionFormatting(): \Iterator {

--- a/tests/Unit/LoggerTraitTest.php
+++ b/tests/Unit/LoggerTraitTest.php
@@ -614,14 +614,14 @@ final class LoggerTraitTest extends UnitTestCase {
    *   Test cases: [input_seconds, expected_output]
    */
   public static function dataProviderFormatElapsedTime(): \Iterator {
-    yield 'short duration' => [5.3, '5s'];
-    yield 'thirty seconds' => [30.2, '30s'];
-    yield 'almost minute' => [59.4, '59s'];
-    yield 'exact minute' => [60.0, '1m'];
-    yield 'two minutes' => [120.0, '2m'];
-    yield 'minute with seconds' => [65.3, '1m 5s'];
-    yield 'longer duration' => [150.2, '2m 30s'];
-    yield 'complex duration' => [345.4, '5m 45s'];
+    yield 'short_duration' => [5.3, '5s'];
+    yield 'thirty_seconds' => [30.2, '30s'];
+    yield 'almost_minute' => [59.4, '59s'];
+    yield 'exact_minute' => [60.0, '1m'];
+    yield 'two_minutes' => [120.0, '2m'];
+    yield 'minute_with_seconds' => [65.3, '1m 5s'];
+    yield 'longer_duration' => [150.2, '2m 30s'];
+    yield 'complex_duration' => [345.4, '5m 45s'];
   }
 
   /**
@@ -892,16 +892,16 @@ final class LoggerTraitTest extends UnitTestCase {
    *   Test cases: [verbose_mode, test_description, test_method]
    */
   public static function dataProviderLoggerMethodsVerboseMode(): \Iterator {
-    yield 'log verbose' => [TRUE, 'log method', fn($self) => $self::log('Test message')];
-    yield 'log silent' => [FALSE, 'log method', fn($self) => $self::log('Test message')];
-    yield 'logSubstep verbose' => [TRUE, 'logSubstep method', fn($self) => $self::logSubstep('Test substep')];
-    yield 'logSubstep silent' => [FALSE, 'logSubstep method', fn($self) => $self::logSubstep('Test substep')];
-    yield 'logNote verbose' => [TRUE, 'logNote method', fn($self) => $self::logNote('Test note')];
-    yield 'logNote silent' => [FALSE, 'logNote method', fn($self) => $self::logNote('Test note')];
-    yield 'logStepStart verbose' => [TRUE, 'logStepStart method', fn($self) => $self::logStepStart('Test step')];
-    yield 'logStepStart silent' => [FALSE, 'logStepStart method', fn($self) => $self::logStepStart('Test step')];
-    yield 'logStepFinish verbose' => [TRUE, 'logStepFinish method', fn($self) => $self::logStepFinish('Test step')];
-    yield 'logStepFinish silent' => [FALSE, 'logStepFinish method', fn($self) => $self::logStepFinish('Test step')];
+    yield 'log_verbose' => [TRUE, 'log method', fn($self) => $self::log('Test message')];
+    yield 'log_silent' => [FALSE, 'log method', fn($self) => $self::log('Test message')];
+    yield 'log_substep_verbose' => [TRUE, 'logSubstep method', fn($self) => $self::logSubstep('Test substep')];
+    yield 'log_substep_silent' => [FALSE, 'logSubstep method', fn($self) => $self::logSubstep('Test substep')];
+    yield 'log_note_verbose' => [TRUE, 'logNote method', fn($self) => $self::logNote('Test note')];
+    yield 'log_note_silent' => [FALSE, 'logNote method', fn($self) => $self::logNote('Test note')];
+    yield 'log_step_start_verbose' => [TRUE, 'logStepStart method', fn($self) => $self::logStepStart('Test step')];
+    yield 'log_step_start_silent' => [FALSE, 'logStepStart method', fn($self) => $self::logStepStart('Test step')];
+    yield 'log_step_finish_verbose' => [TRUE, 'logStepFinish method', fn($self) => $self::logStepFinish('Test step')];
+    yield 'log_step_finish_silent' => [FALSE, 'logStepFinish method', fn($self) => $self::logStepFinish('Test step')];
   }
 
   /**
@@ -937,10 +937,10 @@ final class LoggerTraitTest extends UnitTestCase {
    *   Test cases: [step_name, message, expected_output_contains]
    */
   public static function dataProviderStepMethods(): \Iterator {
-    yield 'basic step start' => ['testStep', 'Starting process', ['STEP START | testStepMethods', 'Starting process']];
-    yield 'step finish with message' => ['testStep', 'Process completed', ['STEP DONE | testStepMethods', 'Process completed', '0s']];
-    yield 'step start no message' => ['testStep', NULL, ['STEP START | testStepMethods']];
-    yield 'step finish no message' => ['testStep', NULL, ['STEP DONE | testStepMethods', '0s']];
+    yield 'basic_step_start' => ['testStep', 'Starting process', ['STEP START | testStepMethods', 'Starting process']];
+    yield 'step_finish_with_message' => ['testStep', 'Process completed', ['STEP DONE | testStepMethods', 'Process completed', '0s']];
+    yield 'step_start_no_message' => ['testStep', NULL, ['STEP START | testStepMethods']];
+    yield 'step_finish_no_message' => ['testStep', NULL, ['STEP DONE | testStepMethods', '0s']];
   }
 
   /**
@@ -975,10 +975,10 @@ final class LoggerTraitTest extends UnitTestCase {
    *   Test cases: [title, message, double_border, min_width, expected_strings]
    */
   public static function dataProviderSectionFormatting(): \Iterator {
-    yield 'basic title only' => ['BASIC TITLE', NULL, FALSE, 60, ['BASIC TITLE', '---']];
-    yield 'title with message' => ['TITLE', 'Message content', FALSE, 60, ['TITLE', 'Message content', '---']];
-    yield 'double border' => ['DOUBLE', 'Double message', TRUE, 60, ['DOUBLE', 'Double message', '===']];
-    yield 'wide section' => ['WIDE', NULL, FALSE, 100, ['WIDE', '---']];
+    yield 'basic_title_only' => ['BASIC TITLE', NULL, FALSE, 60, ['BASIC TITLE', '---']];
+    yield 'title_with_message' => ['TITLE', 'Message content', FALSE, 60, ['TITLE', 'Message content', '---']];
+    yield 'double_border' => ['DOUBLE', 'Double message', TRUE, 60, ['DOUBLE', 'Double message', '===']];
+    yield 'wide_section' => ['WIDE', NULL, FALSE, 100, ['WIDE', '---']];
   }
 
   /**

--- a/tests/Unit/LoggerTraitTest.php
+++ b/tests/Unit/LoggerTraitTest.php
@@ -30,10 +30,8 @@ final class LoggerTraitTest extends UnitTestCase {
    */
   protected function setUp(): void {
     parent::setUp();
-    // Reset verbose state for each test.
     self::loggerSetVerbose(FALSE);
 
-    // Create memory buffer for capturing output.
     $buffer = fopen('php://memory', 'r+');
     if ($buffer === FALSE) {
       throw new \RuntimeException('Failed to create memory buffer');
@@ -41,7 +39,6 @@ final class LoggerTraitTest extends UnitTestCase {
     $this->logBuffer = $buffer;
     self::loggerSetOutputStream($this->logBuffer);
 
-    // Reset steps tracking arrays for each test.
     $reflection_class = new \ReflectionClass(self::class);
     $steps_property = $reflection_class->getProperty('loggerSteps');
     $steps_property->setValue(NULL, []);
@@ -54,12 +51,10 @@ final class LoggerTraitTest extends UnitTestCase {
    * {@inheritdoc}
    */
   protected function tearDown(): void {
-    // Close the memory buffer.
     if (is_resource($this->logBuffer)) {
       fclose($this->logBuffer);
     }
 
-    // Reset output stream to default.
     self::loggerSetOutputStream(NULL);
 
     parent::tearDown();
@@ -80,7 +75,6 @@ final class LoggerTraitTest extends UnitTestCase {
    * Test verbose mode setter and getter.
    */
   public function testVerboseMode(): void {
-    // Test verbose enabled.
     self::loggerSetVerbose(TRUE);
     self::log('Verbose message');
     self::logSection('Verbose Section', 'Verbose content');
@@ -90,7 +84,6 @@ final class LoggerTraitTest extends UnitTestCase {
     $this->assertStringContainsString('Verbose Section', $output);
     $this->assertStringContainsString('Verbose content', $output);
 
-    // Reset buffer and test verbose disabled.
     $buffer = fopen('php://memory', 'r+');
     if ($buffer === FALSE) {
       throw new \RuntimeException('Failed to create memory buffer');
@@ -114,7 +107,6 @@ final class LoggerTraitTest extends UnitTestCase {
 
     self::log('Test message');
 
-    // Should produce no output when verbose is disabled.
     $output = $this->getCapturedOutput();
     $this->assertEmpty($output);
   }
@@ -127,7 +119,6 @@ final class LoggerTraitTest extends UnitTestCase {
 
     self::log('Test message');
 
-    // Should produce output when verbose is enabled.
     $output = $this->getCapturedOutput();
     $this->assertSame("\nTest message\n", $output);
   }
@@ -138,19 +129,16 @@ final class LoggerTraitTest extends UnitTestCase {
   public function testLogSection(): void {
     self::loggerSetVerbose(TRUE);
 
-    // Test basic section.
     self::logSection('TEST TITLE');
 
-    // Test section with message.
     self::logSection('TEST TITLE', 'Test message content');
 
-    // Test section with double border.
+    // Double border.
     self::logSection('TEST TITLE', 'Test message', TRUE);
 
-    // Test section with custom width.
+    // Custom width.
     self::logSection('TEST TITLE', NULL, FALSE, 80);
 
-    // Verify the output contains expected elements.
     $output = $this->getCapturedOutput();
     $this->assertStringContainsString('TEST TITLE', $output);
     $this->assertStringContainsString('Test message content', $output);
@@ -192,15 +180,12 @@ final class LoggerTraitTest extends UnitTestCase {
   public function testLogFileWithExistingFile(): void {
     self::loggerSetVerbose(TRUE);
 
-    // Create a temporary file.
     $temp_file = tempnam(sys_get_temp_dir(), 'logger_test');
     file_put_contents($temp_file, 'Test file content');
 
-    // Test logging the file.
     self::logFile($temp_file);
     self::logFile($temp_file, 'Custom message');
 
-    // Clean up.
     unlink($temp_file);
   }
 
@@ -210,11 +195,9 @@ final class LoggerTraitTest extends UnitTestCase {
   public function testLogFileWithUnreadableFile(): void {
     self::loggerSetVerbose(TRUE);
 
-    // Create a temporary file.
     $temp_file = tempnam(sys_get_temp_dir(), 'logger_test');
     file_put_contents($temp_file, 'Test content');
 
-    // Change permissions to make file unreadable.
     chmod($temp_file, 0000);
 
     $this->expectException(\RuntimeException::class);
@@ -224,7 +207,6 @@ final class LoggerTraitTest extends UnitTestCase {
       self::logFile($temp_file);
     }
     finally {
-      // Restore permissions and clean up.
       chmod($temp_file, 0644);
       unlink($temp_file);
     }
@@ -249,14 +231,11 @@ final class LoggerTraitTest extends UnitTestCase {
   public function testLogFileWithVerboseDisabled(): void {
     self::loggerSetVerbose(FALSE);
 
-    // Create a temporary file.
     $temp_file = tempnam(sys_get_temp_dir(), 'logger_test');
     file_put_contents($temp_file, 'Test content');
 
-    // This should not output anything and not throw exceptions.
     self::logFile($temp_file);
 
-    // Clean up.
     unlink($temp_file);
   }
 
@@ -267,7 +246,6 @@ final class LoggerTraitTest extends UnitTestCase {
   public function testLogSectionWithVerboseDisabled(): void {
     self::loggerSetVerbose(FALSE);
 
-    // This should not output anything and not throw exceptions.
     self::logSection('TEST TITLE', 'Test message');
   }
 
@@ -278,11 +256,9 @@ final class LoggerTraitTest extends UnitTestCase {
   public function testSilentModeForAllMethods(): void {
     self::loggerSetVerbose(FALSE);
 
-    // All these should execute without output.
     self::log('Test message');
     self::logSection('TEST TITLE', 'Test message');
 
-    // Create temp file for logFile test.
     $temp_file = tempnam(sys_get_temp_dir(), 'logger_test');
     file_put_contents($temp_file, 'Test content');
     self::logFile($temp_file);
@@ -294,16 +270,12 @@ final class LoggerTraitTest extends UnitTestCase {
    */
   #[DoesNotPerformAssertions]
   public function testVerboseModePersistence(): void {
-    // Set verbose mode.
     self::loggerSetVerbose(TRUE);
 
-    // Call various methods.
     self::log('Message 1');
 
-    // Disable verbose mode.
     self::loggerSetVerbose(FALSE);
 
-    // Call methods again.
     self::log('Message 2');
   }
 
@@ -313,7 +285,6 @@ final class LoggerTraitTest extends UnitTestCase {
   public function testLogStepStartVerboseMode(): void {
     self::loggerSetVerbose(TRUE);
 
-    // Test step start without message.
     self::logStepStart();
 
     $output = $this->getCapturedOutput();
@@ -327,7 +298,6 @@ final class LoggerTraitTest extends UnitTestCase {
   public function testLogStepStartWithCustomPrefix(): void {
     self::loggerSetVerbose(TRUE);
 
-    // Set custom prefix.
     $original_prefix = self::$loggerStepMethodPrefix;
     self::$loggerStepMethodPrefix = 'process';
 
@@ -338,7 +308,6 @@ final class LoggerTraitTest extends UnitTestCase {
       $this->assertStringContainsString('PROCESS START | processTest', $output);
     }
     finally {
-      // Restore original prefix.
       self::$loggerStepMethodPrefix = $original_prefix;
     }
   }
@@ -350,7 +319,6 @@ final class LoggerTraitTest extends UnitTestCase {
   public function testLogStepStartSilentMode(): void {
     self::loggerSetVerbose(FALSE);
 
-    // This should not output anything and not throw exceptions.
     self::logStepStart();
     self::logStepStart('Silent step start');
   }
@@ -361,7 +329,6 @@ final class LoggerTraitTest extends UnitTestCase {
   public function testLogStepFinishVerboseMode(): void {
     self::loggerSetVerbose(TRUE);
 
-    // Start a step first, then finish it to test elapsed time.
     self::logStepStart();
     self::logStepFinish('Completed the test step');
 
@@ -377,7 +344,6 @@ final class LoggerTraitTest extends UnitTestCase {
   public function testLogStepFinishWithCustomPrefix(): void {
     self::loggerSetVerbose(TRUE);
 
-    // Set custom prefix.
     $original_prefix = self::$loggerStepMethodPrefix;
     self::$loggerStepMethodPrefix = 'process';
 
@@ -389,7 +355,6 @@ final class LoggerTraitTest extends UnitTestCase {
       $this->assertStringContainsString('PROCESS DONE | processFinishTest | 0s', $output);
     }
     finally {
-      // Restore original prefix.
       self::$loggerStepMethodPrefix = $original_prefix;
     }
   }
@@ -401,7 +366,6 @@ final class LoggerTraitTest extends UnitTestCase {
   public function testLogStepFinishSilentMode(): void {
     self::loggerSetVerbose(FALSE);
 
-    // This should not output anything and not throw exceptions.
     self::logStepFinish();
     self::logStepFinish('Silent step finish');
   }
@@ -413,7 +377,6 @@ final class LoggerTraitTest extends UnitTestCase {
   public function testLogSubstepVerboseMode(): void {
     self::loggerSetVerbose(TRUE);
 
-    // Test substep logging.
     self::logSubstep('Processing substep 1');
     self::logSubstep('Processing substep 2');
   }
@@ -425,7 +388,6 @@ final class LoggerTraitTest extends UnitTestCase {
   public function testLogSubstepSilentMode(): void {
     self::loggerSetVerbose(FALSE);
 
-    // This should not output anything and not throw exceptions.
     self::logSubstep('Silent substep');
   }
 
@@ -436,7 +398,6 @@ final class LoggerTraitTest extends UnitTestCase {
   public function testLogNoteVerboseMode(): void {
     self::loggerSetVerbose(TRUE);
 
-    // Test note logging.
     self::logNote('Important note about the process');
     self::logNote('Another note with details');
   }
@@ -448,7 +409,6 @@ final class LoggerTraitTest extends UnitTestCase {
   public function testLogNoteSilentMode(): void {
     self::loggerSetVerbose(FALSE);
 
-    // This should not output anything and not throw exceptions.
     self::logNote('Silent note');
   }
 
@@ -458,7 +418,6 @@ final class LoggerTraitTest extends UnitTestCase {
   public function testStepLoggingWorkflow(): void {
     self::loggerSetVerbose(TRUE);
 
-    // Test a complete step workflow.
     self::logStepStart('Test workflow');
     self::logSubstep('Initializing');
     self::logNote('Setting up test data');
@@ -466,7 +425,6 @@ final class LoggerTraitTest extends UnitTestCase {
     self::logNote('Performing calculations');
     self::logStepFinish('Test workflow completed');
 
-    // Verify the output contains all expected elements.
     $output = $this->getCapturedOutput();
     $this->assertStringContainsString('STEP START | testStepLoggingWorkflow', $output);
     $this->assertStringContainsString('STEP DONE | testStepLoggingWorkflow | 0s', $output);
@@ -484,7 +442,6 @@ final class LoggerTraitTest extends UnitTestCase {
    * With visual output for inspection.
    */
   public function testStepMethodsRespectVerboseMode(): void {
-    // Test with verbose disabled - should be silent.
     self::loggerSetVerbose(FALSE);
     self::logStepStart('Silent step');
     self::logSubstep('Silent substep');
@@ -494,7 +451,6 @@ final class LoggerTraitTest extends UnitTestCase {
     $silent_output = $this->getCapturedOutput();
     $this->assertEmpty($silent_output);
 
-    // Reset buffer and steps tracking, then test with verbose enabled.
     $buffer = fopen('php://memory', 'r+');
     if ($buffer === FALSE) {
       throw new \RuntimeException('Failed to create memory buffer');
@@ -502,7 +458,7 @@ final class LoggerTraitTest extends UnitTestCase {
     $this->logBuffer = $buffer;
     self::loggerSetOutputStream($this->logBuffer);
 
-    // Clear steps array to prevent interference from silent calls.
+    // Clear steps tracked by the silent calls to avoid interference.
     $reflection_class = new \ReflectionClass(self::class);
     $steps_property = $reflection_class->getProperty('loggerSteps');
     $steps_property->setValue(NULL, []);
@@ -513,7 +469,6 @@ final class LoggerTraitTest extends UnitTestCase {
     self::logNote('Verbose note');
     self::logStepFinish('Verbose step end');
 
-    // Verify verbose output contains expected content.
     $verbose_output = $this->getCapturedOutput();
     $this->assertStringContainsString('STEP START | testStepMethodsRespectVerboseMode', $verbose_output);
     $this->assertStringContainsString('STEP DONE | testStepMethodsRespectVerboseMode | 0s', $verbose_output);
@@ -530,9 +485,8 @@ final class LoggerTraitTest extends UnitTestCase {
   public function testElapsedTimeCalculation(): void {
     self::loggerSetVerbose(TRUE);
 
-    // Test step with elapsed time.
     self::logStepStart('Timed step');
-    // Sleep for 1.5 seconds to show measurable elapsed time.
+    // Delay long enough to show measurable elapsed time.
     usleep(1500000);
     self::logStepFinish('Timed step completed');
   }
@@ -544,7 +498,7 @@ final class LoggerTraitTest extends UnitTestCase {
   public function testLogStepFinishWithoutStart(): void {
     self::loggerSetVerbose(TRUE);
 
-    // This should not show elapsed time and not throw exceptions.
+    // A finish without a start shows no elapsed time and does not throw.
     self::logStepFinish('Orphan step');
   }
 
@@ -555,15 +509,13 @@ final class LoggerTraitTest extends UnitTestCase {
   public function testStepRestart(): void {
     self::loggerSetVerbose(TRUE);
 
-    // Start first step.
     self::logStepStart('First step');
 
-    // Start second step without finishing first (should restart timer).
+    // A second start without a finish restarts the timer.
     self::logStepStart('Second step');
-    // Sleep for 10ms.
     usleep(10000);
 
-    // Finish second step (should show elapsed time for second step).
+    // The finish shows elapsed time for the second step.
     self::logStepFinish('Second step completed');
   }
 
@@ -574,11 +526,9 @@ final class LoggerTraitTest extends UnitTestCase {
   public function testStepNameMismatch(): void {
     self::loggerSetVerbose(TRUE);
 
-    // Manually add a step with different method name to the tracking array.
     $reflection_class = new \ReflectionClass(self::class);
     $steps_property = $reflection_class->getProperty('loggerSteps');
 
-    // Add a step with a different name that won't match the current method.
     $steps_property->setValue(NULL, [
       [
         'name' => 'differentMethodName',
@@ -588,7 +538,7 @@ final class LoggerTraitTest extends UnitTestCase {
       ],
     ]);
 
-    // This should not show elapsed time since method names don't match.
+    // No elapsed time is shown because the method names do not match.
     self::logStepFinish('Current method');
   }
 
@@ -627,7 +577,6 @@ final class LoggerTraitTest extends UnitTestCase {
   public function testLogStepSummaryWithNoSteps(): void {
     self::loggerSetVerbose(TRUE);
 
-    // Should produce no output when no steps tracked.
     self::logStepSummary();
 
     $output = $this->getCapturedOutput();
@@ -640,14 +589,12 @@ final class LoggerTraitTest extends UnitTestCase {
   public function testLogStepSummaryWithVerboseDisabled(): void {
     self::loggerSetVerbose(FALSE);
 
-    // Add some steps to tracking array - these should be silent.
     self::logStepStart('Test step');
     self::logStepFinish('Test step');
 
     // Clear output from any potential leakage.
     $this->getCapturedOutput();
 
-    // Reset buffer.
     $buffer = fopen('php://memory', 'r+');
     if ($buffer === FALSE) {
       throw new \RuntimeException('Failed to create memory buffer');
@@ -655,7 +602,6 @@ final class LoggerTraitTest extends UnitTestCase {
     $this->logBuffer = $buffer;
     self::loggerSetOutputStream($this->logBuffer);
 
-    // Should not output anything.
     self::logStepSummary();
 
     $output = $this->getCapturedOutput();
@@ -667,7 +613,7 @@ final class LoggerTraitTest extends UnitTestCase {
    */
   public function testLogStepSummaryWithMixedSteps(): void {
     self::logStepStart('Completed step');
-    // 1.2 second delay to show measurable time.
+    // Delay long enough to show measurable time.
     usleep(1200000);
     self::logStepFinish('Completed step');
 
@@ -717,14 +663,12 @@ final class LoggerTraitTest extends UnitTestCase {
   public function testStepArrayTracking(): void {
     self::loggerSetVerbose(TRUE);
 
-    // Access the steps array via reflection.
     $reflection_class = new \ReflectionClass(self::class);
     $steps_property = $reflection_class->getProperty('loggerSteps');
 
-    // Initially should be empty.
     $this->assertEmpty($steps_property->getValue());
 
-    // Add first step (name comes from method name, not parameter).
+    // The step name comes from the calling method, not the parameter.
     self::logStepStart('First step message');
     $steps = $steps_property->getValue();
     $this->assertIsArray($steps);
@@ -734,7 +678,6 @@ final class LoggerTraitTest extends UnitTestCase {
     // @phpstan-ignore-next-line offsetAccess.nonOffsetAccessible
     $this->assertNull($steps[0]['end_time']);
 
-    // Finish first step.
     self::logStepFinish('First step completed');
     $steps = $steps_property->getValue();
     $this->assertIsArray($steps);
@@ -743,7 +686,6 @@ final class LoggerTraitTest extends UnitTestCase {
     // @phpstan-ignore-next-line offsetAccess.nonOffsetAccessible
     $this->assertNotNull($steps[0]['elapsed']);
 
-    // Add second step.
     self::logStepStart('Second step message');
     $steps = $steps_property->getValue();
     $this->assertIsArray($steps);
@@ -758,7 +700,6 @@ final class LoggerTraitTest extends UnitTestCase {
   public function testLoggerSetOutputStream(): void {
     self::loggerSetVerbose(TRUE);
 
-    // Create a custom buffer.
     $custom_buffer = fopen('php://memory', 'r+');
     if ($custom_buffer === FALSE) {
       throw new \RuntimeException('Failed to create custom buffer');
@@ -780,10 +721,8 @@ final class LoggerTraitTest extends UnitTestCase {
   public function testLoggerOutputStreamFallback(): void {
     self::loggerSetVerbose(TRUE);
 
-    // Set stream to NULL (should fallback to STDERR).
     self::loggerSetOutputStream(NULL);
 
-    // Use reflection to test the getOutputStream method.
     $reflection_class = new \ReflectionClass(self::class);
     $method = $reflection_class->getMethod('getOutputStream');
 
@@ -798,7 +737,6 @@ final class LoggerTraitTest extends UnitTestCase {
     $this->expectException(\InvalidArgumentException::class);
     $this->expectExceptionMessage('Stream must be a valid resource or NULL.');
 
-    // Try to set an invalid stream (string instead of resource).
     // @phpstan-ignore-next-line argument.type
     self::loggerSetOutputStream('invalid_stream');
   }
@@ -836,10 +774,8 @@ final class LoggerTraitTest extends UnitTestCase {
       throw new \RuntimeException('Failed to create test resource');
     }
 
-    // Should not throw an exception.
     self::loggerSetOutputStream($valid_resource);
 
-    // Verify it was set correctly.
     $reflection_class = new \ReflectionClass(self::class);
     $method = $reflection_class->getMethod('getOutputStream');
 
@@ -910,12 +846,10 @@ final class LoggerTraitTest extends UnitTestCase {
   public function testStepMethods(string $step_name, ?string $message, array $expected_output): void {
     self::loggerSetVerbose(TRUE);
 
-    // Test both start and finish for completeness.
     if (str_contains($expected_output[0], 'START')) {
       self::logStepStart($message);
     }
     else {
-      // First start a step, then finish it.
       self::logStepStart('Initial step');
       self::logStepFinish($message);
     }
@@ -949,7 +883,6 @@ final class LoggerTraitTest extends UnitTestCase {
   public function testSectionFormatting(string $title, ?string $message, bool $double_border, int $min_width, array $expected_strings): void {
     self::loggerSetVerbose(TRUE);
 
-    // Reset buffer for each test case.
     $buffer = fopen('php://memory', 'r+');
     if ($buffer === FALSE) {
       throw new \RuntimeException('Failed to create memory buffer');
@@ -1002,13 +935,11 @@ final class LoggerTraitTest extends UnitTestCase {
   public function testHierarchicalStepTracking(): void {
     self::loggerSetVerbose(TRUE);
 
-    // Access the steps array via reflection.
     $reflection_class = new \ReflectionClass(self::class);
     $steps_property = $reflection_class->getProperty('loggerSteps');
 
     $stack_property = $reflection_class->getProperty('loggerStepStack');
 
-    // Test nested steps.
     self::logStepStart('Level 1');
     $steps = $steps_property->getValue();
     $stack = $stack_property->getValue();
@@ -1019,7 +950,6 @@ final class LoggerTraitTest extends UnitTestCase {
     $this->assertEmpty($steps[0]['parent_stack']);
     $this->assertSame(['testHierarchicalStepTracking'], $stack);
 
-    // Start nested step.
     self::logStepStart('Level 2');
     $steps = $steps_property->getValue();
     $stack = $stack_property->getValue();
@@ -1030,7 +960,6 @@ final class LoggerTraitTest extends UnitTestCase {
     $this->assertSame(['testHierarchicalStepTracking'], $steps[1]['parent_stack']);
     $this->assertSame(['testHierarchicalStepTracking', 'testHierarchicalStepTracking'], $stack);
 
-    // Start deeply nested step.
     self::logStepStart('Level 3');
     $steps = $steps_property->getValue();
     $stack = $stack_property->getValue();
@@ -1041,17 +970,14 @@ final class LoggerTraitTest extends UnitTestCase {
     $this->assertSame(['testHierarchicalStepTracking', 'testHierarchicalStepTracking'], $steps[2]['parent_stack']);
     $this->assertSame(['testHierarchicalStepTracking', 'testHierarchicalStepTracking', 'testHierarchicalStepTracking'], $stack);
 
-    // Finish level 3.
     self::logStepFinish('Level 3 done');
     $stack = $stack_property->getValue();
     $this->assertSame(['testHierarchicalStepTracking', 'testHierarchicalStepTracking'], $stack);
 
-    // Finish level 2.
     self::logStepFinish('Level 2 done');
     $stack = $stack_property->getValue();
     $this->assertSame(['testHierarchicalStepTracking'], $stack);
 
-    // Finish level 1.
     self::logStepFinish('Level 1 done');
     $stack = $stack_property->getValue();
     $this->assertEmpty($stack);
@@ -1061,7 +987,6 @@ final class LoggerTraitTest extends UnitTestCase {
    * Test configurable step indentation.
    */
   public function testConfigurableStepIndentation(): void {
-    // Create nested steps.
     self::logStepStart('Parent step');
     self::logStepStart('Child step');
     self::logStepFinish('Child completed');
@@ -1076,7 +1001,6 @@ final class LoggerTraitTest extends UnitTestCase {
    * Test step summary with hierarchical indentation display.
    */
   public function testStepSummaryHierarchicalDisplay(): void {
-    // Create a hierarchy of steps.
     self::logStepStart('Main process');
     self::logStepStart('Sub process');
     self::logStepStart('Deep process');
@@ -1107,7 +1031,6 @@ final class LoggerTraitTest extends UnitTestCase {
    * Test logStepSummary with no steps.
    */
   public function testLogStepSummaryEmpty(): void {
-    // Should return empty string when no steps.
     $result = self::logStepSummary();
     $this->assertSame('', $result);
   }

--- a/tests/Unit/LoggerTraitTest.php
+++ b/tests/Unit/LoggerTraitTest.php
@@ -23,7 +23,7 @@ final class LoggerTraitTest extends UnitTestCase {
    *
    * @var resource
    */
-  private $logBuffer;
+  protected $logBuffer;
 
   /**
    * {@inheritdoc}
@@ -71,7 +71,7 @@ final class LoggerTraitTest extends UnitTestCase {
    * @return string
    *   The captured output.
    */
-  private function getCapturedOutput(): string {
+  protected function getCapturedOutput(): string {
     rewind($this->logBuffer);
     return stream_get_contents($this->logBuffer);
   }
@@ -964,7 +964,7 @@ final class LoggerTraitTest extends UnitTestCase {
 
     $output = $this->getCapturedOutput();
     foreach ($expected_strings as $expected_string) {
-      $this->assertStringContainsString($expected_string, $output, 'Failed for title: ' . $title);
+      $this->assertStringContainsString($expected_string, $output, sprintf('Failed for title: %s', $title));
     }
   }
 
@@ -1143,7 +1143,7 @@ final class LoggerTraitTest extends UnitTestCase {
   /**
    * Helper method that starts with 'process' prefix for testing.
    */
-  private function processTest(): void {
+  protected function processTest(): void {
     self::logStepStart('Testing process prefix');
     self::logStepFinish('Process prefix test completed');
   }
@@ -1151,7 +1151,7 @@ final class LoggerTraitTest extends UnitTestCase {
   /**
    * Helper method that starts with 'process' prefix for testing finish.
    */
-  private function processFinishTest(): void {
+  protected function processFinishTest(): void {
     self::logStepStart('Testing process finish');
     self::logStepFinish('Process finish test completed');
   }

--- a/tests/Unit/ProcessTraitTest.php
+++ b/tests/Unit/ProcessTraitTest.php
@@ -513,9 +513,9 @@ final class ProcessTraitTest extends UnitTestCase {
       $prefix = $type === Process::ERR ? self::$processStreamingErrorOutputChars : self::$processStreamingStandardOutputChars;
 
       $parts = preg_split('/(\r\n|\n|\r)/', $buffer, -1, PREG_SPLIT_DELIM_CAPTURE);
-      $counter = is_array($parts) ? count($parts) : 0;
+      $count = is_array($parts) ? count($parts) : 0;
 
-      for ($i = 0; $i < $counter; $i += 2) {
+      for ($i = 0; $i < $count; $i += 2) {
         $line = $parts[$i] ?? '';
         $eol = $parts[$i + 1] ?? '';
 
@@ -694,9 +694,9 @@ EOL;
       $prefix = $type === Process::ERR ? self::$processStreamingErrorOutputChars : self::$processStreamingStandardOutputChars;
 
       $parts = preg_split('/(\r\n|\n|\r)/', $buffer, -1, PREG_SPLIT_DELIM_CAPTURE);
-      $counter = is_array($parts) ? count($parts) : 0;
+      $count = is_array($parts) ? count($parts) : 0;
 
-      for ($i = 0; $i < $counter; $i += 2) {
+      for ($i = 0; $i < $count; $i += 2) {
         $line = $parts[$i] ?? '';
         $eol = $parts[$i + 1] ?? '';
 
@@ -723,9 +723,9 @@ EOL;
       $prefix = $type === Process::ERR ? self::$processStreamingErrorOutputChars : self::$processStreamingStandardOutputChars;
 
       $parts = preg_split('/(\r\n|\n|\r)/', $buffer, -1, PREG_SPLIT_DELIM_CAPTURE);
-      $counter = is_array($parts) ? count($parts) : 0;
+      $count = is_array($parts) ? count($parts) : 0;
 
-      for ($i = 0; $i < $counter; $i += 2) {
+      for ($i = 0; $i < $count; $i += 2) {
         $line = $parts[$i] ?? '';
         $eol = $parts[$i + 1] ?? '';
 
@@ -767,9 +767,9 @@ EOL;
       $prefix = $type === Process::ERR ? self::$processStreamingErrorOutputChars : self::$processStreamingStandardOutputChars;
 
       $parts = preg_split('/(\r\n|\n|\r)/', $buffer, -1, PREG_SPLIT_DELIM_CAPTURE);
-      $counter = is_array($parts) ? count($parts) : 0;
+      $count = is_array($parts) ? count($parts) : 0;
 
-      for ($i = 0; $i < $counter; $i += 2) {
+      for ($i = 0; $i < $count; $i += 2) {
         $line = $parts[$i] ?? '';
         $eol = $parts[$i + 1] ?? '';
 

--- a/tests/Unit/ProcessTraitTest.php
+++ b/tests/Unit/ProcessTraitTest.php
@@ -1022,7 +1022,7 @@ EOL;
     $result = $method->invoke($this, $command);
 
     if ($exception_message === NULL) {
-      $this->assertEquals($expected, $result);
+      $this->assertSame($expected, $result);
     }
   }
 

--- a/tests/Unit/ProcessTraitTest.php
+++ b/tests/Unit/ProcessTraitTest.php
@@ -381,7 +381,7 @@ final class ProcessTraitTest extends UnitTestCase {
     $this->process = NULL;
 
     $this->expectException(ExpectationFailedException::class);
-    $this->expectExceptionMessage('Process should be initialized');
+    $this->expectExceptionMessage('Process is not initialized');
 
     $this->assertProcessSuccessful();
   }

--- a/tests/Unit/ProcessTraitTest.php
+++ b/tests/Unit/ProcessTraitTest.php
@@ -499,9 +499,6 @@ final class ProcessTraitTest extends UnitTestCase {
 
     $command = self::$fixtures . '/shell-command-failing.sh';
 
-    // Create a temporary file to capture the streaming output.
-    tempnam(sys_get_temp_dir(), 'test_stream_output');
-
     // Override processStreamingOutputCallback method temporarily.
     $reflection = new \ReflectionClass($this);
     $property = $reflection->getProperty('processStreamOutput');
@@ -752,9 +749,6 @@ EOL;
       $test_callback(Process::ERR, $input);
     }
 
-    // If we get here without exceptions, the callback handled input correctly.
-    $this->addToAssertionCount(count($test_inputs) * 2);
-
     // Verify some expected output was captured.
     $this->assertStringContainsString(self::$processStreamingStandardOutputChars, $captured_output);
     $this->assertStringContainsString(self::$processStreamingErrorOutputChars, $captured_output);
@@ -784,9 +778,6 @@ EOL;
     // Call with error type - should not throw exceptions.
     $test_callback(Process::ERR, "error message\n");
     $test_callback(Process::OUT, "standard message\n");
-
-    // If we get here without exceptions, the callback is working.
-    $this->addToAssertionCount(1);
 
     // Verify expected output was captured with correct prefixes.
     $this->assertStringContainsString(self::$processStreamingErrorOutputChars . 'error message', $captured_output);
@@ -1290,9 +1281,6 @@ EOL;
     // Test with empty strings to avoid visible output.
     $callback(Process::OUT, "");
     $callback(Process::ERR, "");
-
-    // If we reach here, the callback executed without errors.
-    $this->addToAssertionCount(1);
   }
 
   public function testProcessRunWithZeroArguments(): void {

--- a/tests/Unit/ProcessTraitTest.php
+++ b/tests/Unit/ProcessTraitTest.php
@@ -194,17 +194,14 @@ final class ProcessTraitTest extends UnitTestCase {
 
     $this->assertProcessSuccessful();
 
-    // Test assertProcessAnyOutputContains.
     $this->assertProcessAnyOutputContains('Standard Output');
     $this->assertProcessAnyOutputContains('Error Output');
     $this->assertProcessAnyOutputContains(['Standard', 'Error']);
     $this->assertProcessAnyOutputContains(['Standard Output', 'Error Output']);
 
-    // Test assertProcessAnyOutputNotContains.
     $this->assertProcessAnyOutputNotContains('Nonexistent String');
     $this->assertProcessAnyOutputNotContains(['NotFound1', 'NotFound2']);
 
-    // Test assertProcessAnyOutputContainsOrNot.
     $this->assertProcessAnyOutputContainsOrNot([
       '* Standard Output',
       '* Error Output',
@@ -234,7 +231,7 @@ final class ProcessTraitTest extends UnitTestCase {
 
     $this->assertProcessSuccessful();
 
-    // Test shortcut mode - no prefixes, all should be present.
+    // Without prefixes, every string must be present.
     $this->assertProcessAnyOutputContainsOrNot([
       'Test Output',
       'Test',
@@ -248,7 +245,6 @@ final class ProcessTraitTest extends UnitTestCase {
     $this->expectException(\RuntimeException::class);
     $this->expectExceptionMessage('All strings must have valid prefixes in mixed mode');
 
-    // This should fail - mixed usage (some with prefix, some without)
     $this->assertProcessAnyOutputContainsOrNot([
       '* Test Output',
       'Missing prefix',
@@ -284,12 +280,10 @@ final class ProcessTraitTest extends UnitTestCase {
 
     $this->assertProcessSuccessful();
 
-    // Test exact match present.
     $this->assertProcessOutputContainsOrNot([
       '+ Hello World',
     ]);
 
-    // Test exact match absent.
     $this->assertProcessOutputContainsOrNot([
       '- Not exact match',
     ]);
@@ -300,12 +294,10 @@ final class ProcessTraitTest extends UnitTestCase {
 
     $this->assertProcessSuccessful();
 
-    // Test exact match present for error output.
     $this->assertProcessErrorOutputContainsOrNot([
       '+ Error Message',
     ]);
 
-    // Test exact match absent.
     $this->assertProcessErrorOutputContainsOrNot([
       '- Not this error',
     ]);
@@ -316,12 +308,10 @@ final class ProcessTraitTest extends UnitTestCase {
 
     $this->assertProcessSuccessful();
 
-    // Test exact match present for combined output.
     $this->assertProcessAnyOutputContainsOrNot([
       '+ Standard' . "\n" . 'Error',
     ]);
 
-    // Test exact match absent.
     $this->assertProcessAnyOutputContainsOrNot([
       '- Not the output',
     ]);
@@ -332,17 +322,15 @@ final class ProcessTraitTest extends UnitTestCase {
 
     $this->assertProcessSuccessful();
 
-    // Test exact match with multi-line output.
     $this->assertProcessOutputContainsOrNot([
       '+ Line 1' . "\n" . 'Line 2' . "\n" . 'Line 3',
     ]);
 
-    // Test substring match for individual line.
     $this->assertProcessOutputContainsOrNot([
       '* Line 2',
     ]);
 
-    // Exact match should fail for single line when output has multiple.
+    // Exact match of a single line fails when the output has multiple lines.
     $this->assertProcessOutputContainsOrNot([
       '- Line 1',
     ]);
@@ -477,19 +465,11 @@ final class ProcessTraitTest extends UnitTestCase {
   }
 
   /**
-   * Test process streaming output callback functionality.
+   * Tests streaming output callback prefixing and line-ending handling.
    *
-   * This test verifies that the processStreamingOutputCallback() correctly:
-   * - Prefixes standard output with '>>'
-   * - Prefixes error output with 'XX'
-   * - Handles line endings properly.
-   *
-   * Important note about output order:
-   * The expected output order may not match the exact script execution order
-   * due to stdio buffering behavior when processes output to pipes:
-   * - stdout becomes block-buffered when piped (waits for buffer to fill)
-   * - stderr is typically unbuffered (flushes immediately)
-   * This is standard Unix/Linux behavior and affects how Symfony Process
+   * The expected output order can differ from the script execution order:
+   * piped stdout is block-buffered while stderr is typically unbuffered.
+   * This is standard Unix/Linux behavior that affects how Symfony Process
    * receives the output through pipes, not a bug in the streaming callback.
    */
   public function testProcessStreamingOutput(): void {
@@ -536,7 +516,6 @@ final class ProcessTraitTest extends UnitTestCase {
     $this->process->setIdleTimeout(30);
     $this->process->run($capture_callback);
 
-    // Verify the process failed as expected.
     $this->assertProcessFailed();
 
     $expected_lines = <<<EOL
@@ -563,7 +542,6 @@ XX ERROR: Operation aborted
 XX === Complex Operation Failed ===
 EOL;
 
-    // Split expected output into lines and assert each line is present.
     $expected_lines_array = explode(PHP_EOL, $expected_lines);
     foreach ($expected_lines_array as $expected_line) {
       $this->assertStringContainsString($expected_line, $captured_output, sprintf("Missing expected line: '%s'", $expected_line));
@@ -644,7 +622,7 @@ EOL;
   public function testProcessTearDownWhenNotInitialized(): void {
     $this->assertNull($this->process);
 
-    // Should not throw any exception.
+    // The processTearDown() call must not throw.
     $this->processTearDown();
 
     $this->assertNull($this->process);
@@ -685,7 +663,7 @@ EOL;
   }
 
   public function testProcessStreamingCallbackWithEmptyBuffer(): void {
-    // Create a test callback that captures output instead of writing to STDOUT.
+    // The callback captures output instead of writing to STDOUT.
     $captured_output = '';
     $test_callback = function ($type, $buffer) use (&$captured_output): void {
       $prefix = $type === Process::ERR ? self::$processStreamingErrorOutputChars : self::$processStreamingStandardOutputChars;
@@ -705,16 +683,14 @@ EOL;
       }
     };
 
-    // Test with empty buffer - should not cause issues or exceptions.
     $test_callback(Process::OUT, '');
     $test_callback(Process::ERR, '');
 
-    // If we get here without exceptions, empty buffers are handled correctly.
     $this->assertSame('', $captured_output);
   }
 
   public function testProcessStreamingCallbackWithDifferentLineEndings(): void {
-    // Create a test callback that captures output instead of writing to STDOUT.
+    // The callback captures output instead of writing to STDOUT.
     $captured_output = '';
     $test_callback = function ($type, $buffer) use (&$captured_output): void {
       $prefix = $type === Process::ERR ? self::$processStreamingErrorOutputChars : self::$processStreamingStandardOutputChars;
@@ -734,7 +710,6 @@ EOL;
       }
     };
 
-    // Test different input patterns.
     $test_inputs = [
       "line1\nline2\n",
       "line1\r\nline2\r\n",
@@ -744,18 +719,16 @@ EOL;
     ];
 
     foreach ($test_inputs as $input) {
-      // Call the callback - it should not throw any exceptions.
       $test_callback(Process::OUT, $input);
       $test_callback(Process::ERR, $input);
     }
 
-    // Verify some expected output was captured.
     $this->assertStringContainsString(self::$processStreamingStandardOutputChars, $captured_output);
     $this->assertStringContainsString(self::$processStreamingErrorOutputChars, $captured_output);
   }
 
   public function testProcessStreamingCallbackWithErrorOutput(): void {
-    // Create a test callback that captures output instead of writing to STDOUT.
+    // The callback captures output instead of writing to STDOUT.
     $captured_output = '';
     $test_callback = function ($type, $buffer) use (&$captured_output): void {
       $prefix = $type === Process::ERR ? self::$processStreamingErrorOutputChars : self::$processStreamingStandardOutputChars;
@@ -775,21 +748,17 @@ EOL;
       }
     };
 
-    // Call with error type - should not throw exceptions.
     $test_callback(Process::ERR, "error message\n");
     $test_callback(Process::OUT, "standard message\n");
 
-    // Verify expected output was captured with correct prefixes.
     $this->assertStringContainsString(self::$processStreamingErrorOutputChars . 'error message', $captured_output);
     $this->assertStringContainsString(self::$processStreamingStandardOutputChars . 'standard message', $captured_output);
   }
 
   public function testProcessRunStopsExistingProcess(): void {
-    // Start first process.
     $this->processRun('echo', ['first process']);
     $first_process = $this->process;
 
-    // Start second process - should stop the first one.
     $this->processRun('echo', ['second process']);
     $second_process = $this->process;
 
@@ -799,7 +768,7 @@ EOL;
   }
 
   public function testProcessRunWithNullInputs(): void {
-    // Test the empty inputs check that converts empty array to NULL.
+    // An empty inputs array is converted to NULL.
     $this->processRun('echo', ['test'], []);
 
     $this->assertProcessSuccessful();
@@ -811,7 +780,7 @@ EOL;
       $this->markTestSkipped('Requires POSIX utilities');
     }
 
-    // Test with actual inputs - this should trigger the implode path.
+    // Non-empty inputs trigger the implode path.
     $this->processRun('cat', [], ['line1', 'line2', 'line3']);
 
     $this->assertProcessSuccessful();
@@ -822,7 +791,6 @@ EOL;
 
   #[DataProvider('dataProviderProcessRunWithCommandString')]
   public function testProcessRunWithCommandString(string $command_string, array $additional_args, array $expected_output): void {
-    // Skip POSIX-specific commands on Windows.
     if (DIRECTORY_SEPARATOR === '\\' && str_starts_with($command_string, 'printf')) {
       $this->markTestSkipped('Requires POSIX utilities');
     }
@@ -902,7 +870,6 @@ EOL;
   }
 
   public function testProcessRunPreservesBackwardCompatibility(): void {
-    // Test that the old array-based approach still works exactly as before.
     $this->processRun('echo', ['hello', 'world']);
 
     $this->assertProcessSuccessful();
@@ -910,7 +877,6 @@ EOL;
   }
 
   public function testProcessRunCommandStringParsing(): void {
-    // Test that command string parsing works correctly.
     $this->processRun('echo test1 test2');
 
     $this->assertProcessSuccessful();
@@ -918,7 +884,6 @@ EOL;
   }
 
   public function testProcessRunCommandStringWithSpecialCharacters(): void {
-    // Test command string with special characters in quotes.
     $this->processRun('echo "Hello! @#$%^&*()"');
 
     $this->assertProcessSuccessful();
@@ -926,7 +891,6 @@ EOL;
   }
 
   public function testProcessRunCommandStringWithFileFlags(): void {
-    // Test realistic file command with flags.
     $this->processRun('echo -e "line1\\nline2"');
 
     $this->assertProcessSuccessful();
@@ -934,8 +898,6 @@ EOL;
   }
 
   public function testProcessRunArgumentOverrideBehavior(): void {
-    // Test how parsed arguments and explicit arguments interact
-    // Parsed arguments come first, explicit arguments are appended.
     $this->processRun('echo parsed1 parsed2', ['explicit1', 'explicit2']);
 
     $this->assertProcessSuccessful();
@@ -943,7 +905,6 @@ EOL;
   }
 
   public function testProcessRunArgumentOrderWithFlags(): void {
-    // Test order with flag-like arguments - parsed flags come first.
     $this->processRun('echo --parsed-flag', ['--explicit-flag']);
 
     $this->assertProcessSuccessful();
@@ -951,26 +912,22 @@ EOL;
   }
 
   public function testProcessRunExplicitArgumentsPrecedence(): void {
-    // Test that parsed arguments come first, explicit arguments are appended
-    // This preserves command structure, especially for -- markers.
+    // Explicit arguments are appended after parsed ones to preserve command
+    // structure, especially -- markers.
     $this->processRun('echo default-arg1 default-arg2', ['override-arg1', 'override-arg2']);
 
     $this->assertProcessSuccessful();
-    // Parsed arguments come first, then explicit arguments.
     $this->assertProcessOutputContains('default-arg1 default-arg2 override-arg1 override-arg2');
   }
 
   public function testProcessRunWithEndOfOptionsAndExplicitArgs(): void {
-    // Test that commands with -- preserve structure with explicit args.
     $this->processRun('echo command -- after-marker', ['explicit']);
 
     $this->assertProcessSuccessful();
-    // Command structure preserved, explicit args appended at end.
     $this->assertProcessOutputContains('command -- after-marker explicit');
   }
 
   public function testProcessRunWithIdleTimeout(): void {
-    // Test the setIdleTimeout path.
     $this->processRun('echo', ['test'], [], [], 10, 5);
 
     $this->assertProcessSuccessful();
@@ -978,7 +935,6 @@ EOL;
   }
 
   public function testProcessFormatOutputWithoutProcessInstance(): void {
-    // Test the case where processFormatOutput is called with no process.
     $this->process = NULL;
 
     $reflection = new \ReflectionClass($this);
@@ -990,8 +946,6 @@ EOL;
   }
 
   public function testStaticVariableAccess(): void {
-    // Test that our static variables have expected values.
-    // Test that they have expected values.
     $this->assertSame('>> ', self::$processStreamingStandardOutputChars);
     $this->assertSame('XX ', self::$processStreamingErrorOutputChars);
     $this->assertStringContainsString('STANDARD OUTPUT', self::$processStandardOutputHeader);
@@ -1270,35 +1224,30 @@ EOL;
   }
 
   public function testProcessStreamingCallbackReturnsCallable(): void {
-    // Test that processStreamingOutputCallback returns a callable.
     $reflection = new \ReflectionClass($this);
     $method = $reflection->getMethod('processStreamingOutputCallback');
     $callback = $method->invoke($this);
 
     $this->assertIsCallable($callback);
 
-    // Test that calling the callback doesn't throw exceptions
-    // Test with empty strings to avoid visible output.
+    // Empty strings avoid visible output.
     $callback(Process::OUT, "");
     $callback(Process::ERR, "");
   }
 
   public function testProcessRunWithZeroArguments(): void {
-    // Test edge case with exactly zero arguments.
     $this->processRun('echo', []);
 
     $this->assertProcessSuccessful();
   }
 
   public function testProcessRunWithEmptyStringArgument(): void {
-    // Test edge case with empty string argument.
     $this->processRun('echo', ['']);
 
     $this->assertProcessSuccessful();
   }
 
   public function testProcessRunWithMixedScalarArguments(): void {
-    // Test with various scalar types to ensure the scalar validation works.
     $this->processRun('echo', ['string', 123, TRUE, 45.67]);
 
     $this->assertProcessSuccessful();
@@ -1309,7 +1258,6 @@ EOL;
       $this->markTestSkipped('Requires POSIX utilities');
     }
 
-    // Test with various scalar types for environment variables.
     $this->processRun('printenv', [], [], [
       'TEST_STRING' => 'value',
       'TEST_INT' => 123,
@@ -1325,11 +1273,10 @@ EOL;
       $this->markTestSkipped('Requires POSIX utilities');
     }
 
-    // First, set an environment variable.
     putenv('TEST_UNSET_VAR=initial_value');
     $this->assertNotFalse(getenv('TEST_UNSET_VAR'));
 
-    // Run a process that unsets the environment variable by passing FALSE.
+    // A FALSE value unsets the variable.
     $this->processRun('printenv', [], [], [
       'TEST_UNSET_VAR' => FALSE,
       'TEST_KEEP_VAR' => 'keep_this',
@@ -1337,13 +1284,10 @@ EOL;
 
     $this->assertProcessSuccessful();
 
-    // The process should not show TEST_UNSET_VAR in its environment.
     $this->assertProcessOutputNotContains('TEST_UNSET_VAR=initial_value');
 
-    // But it should show TEST_KEEP_VAR.
     $this->assertProcessOutputContains('TEST_KEEP_VAR=keep_this');
 
-    // Clean up.
     putenv('TEST_UNSET_VAR');
   }
 
@@ -1352,7 +1296,6 @@ EOL;
       $this->markTestSkipped('Requires POSIX utilities');
     }
 
-    // Test that exit code is properly displayed in formatted output.
     $this->processRun('sh', ['-c', 'exit 42']);
 
     $reflection = new \ReflectionClass($this);
@@ -1364,7 +1307,6 @@ EOL;
   }
 
   public function testAssertProcessSuccessfulWithFailedProcess(): void {
-    // Test the fail() path in assertProcessSuccessful when process failed.
     $this->processRun('sh', ['-c', 'exit 1']);
 
     $this->expectException(AssertionFailedError::class);
@@ -1374,7 +1316,6 @@ EOL;
   }
 
   public function testAssertProcessSuccessfulWithFailedProcessAndMessage(): void {
-    // Test the fail() path in assertProcessSuccessful with custom message.
     $this->processRun('sh', ['-c', 'exit 1']);
 
     $this->expectException(AssertionFailedError::class);
@@ -1385,7 +1326,6 @@ EOL;
   }
 
   public function testAssertProcessFailedWithSuccessfulProcess(): void {
-    // Test the fail() path in assertProcessFailed when process succeeded.
     $this->processRun('echo', ['success']);
 
     $this->expectException(AssertionFailedError::class);
@@ -1395,7 +1335,6 @@ EOL;
   }
 
   public function testAssertProcessFailedWithSuccessfulProcessAndMessage(): void {
-    // Test the fail() path in assertProcessFailed with custom message.
     $this->processRun('echo', ['success']);
 
     $this->expectException(AssertionFailedError::class);
@@ -1484,9 +1423,6 @@ $test->processRun("echo", ["test output"]);
     self::$processStreamingOutputShouldDim = TRUE;
   }
 
-  /**
-   * Test custom failure messages work correctly.
-   */
   public function testCustomFailureMessages(): void {
     $this->processRun('echo', ['test output']);
 

--- a/tests/Unit/ProcessTraitTest.php
+++ b/tests/Unit/ProcessTraitTest.php
@@ -4,13 +4,13 @@ declare(strict_types=1);
 
 namespace AlexSkrypnyk\PhpunitHelpers\Tests\Unit;
 
-use PHPUnit\Framework\AssertionFailedError;
-use Symfony\Component\Process\Process;
 use AlexSkrypnyk\PhpunitHelpers\Traits\ProcessTrait;
 use AlexSkrypnyk\PhpunitHelpers\UnitTestCase;
+use PHPUnit\Framework\AssertionFailedError;
 use PHPUnit\Framework\Attributes\CoversTrait;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\ExpectationFailedException;
+use Symfony\Component\Process\Process;
 
 #[CoversTrait(ProcessTrait::class)]
 final class ProcessTraitTest extends UnitTestCase {

--- a/tests/Unit/ReflectionTraitTest.php
+++ b/tests/Unit/ReflectionTraitTest.php
@@ -16,6 +16,8 @@ final class ReflectionTraitTest extends TestCase {
   protected object $testObject;
 
   protected function setUp(): void {
+    parent::setUp();
+
     $this->testObject = new class() {
 
       protected static function staticProtectedMethod(string $arg): string {

--- a/tests/Unit/ReflectionTraitTest.php
+++ b/tests/Unit/ReflectionTraitTest.php
@@ -66,7 +66,6 @@ final class ReflectionTraitTest extends TestCase {
     $this->expectException(\InvalidArgumentException::class);
     $this->expectExceptionMessage('An object instance is required for non-static methods');
 
-    // Trying to call a non-static method via class name.
     self::callProtectedMethod($this->testObject::class, 'protectedMethod', ['test']);
   }
 

--- a/tests/Unit/SerializableClosureTraitTest.php
+++ b/tests/Unit/SerializableClosureTraitTest.php
@@ -20,7 +20,7 @@ final class SerializableClosureTraitTest extends TestCase {
     $actual = self::cw($closure);
 
     $this->assertInstanceOf(SerializableClosure::class, $actual);
-    $this->assertEquals('test', $actual());
+    $this->assertSame('test', $actual());
   }
 
   public function testCwSerializedClosure(): void {
@@ -35,7 +35,7 @@ final class SerializableClosureTraitTest extends TestCase {
     $actual = self::cu($unserialized);
 
     $this->assertInstanceOf(\Closure::class, $actual);
-    $this->assertEquals('test', $actual());
+    $this->assertSame('test', $actual());
   }
 
   public function fixtureCallable(): string {
@@ -46,7 +46,7 @@ final class SerializableClosureTraitTest extends TestCase {
     $actual = self::cw($this->fixtureCallable(...));
 
     $this->assertInstanceOf(SerializableClosure::class, $actual);
-    $this->assertEquals('test', $actual());
+    $this->assertSame('test', $actual());
   }
 
   public function testCwSerializedCallable(): void {
@@ -59,7 +59,7 @@ final class SerializableClosureTraitTest extends TestCase {
     $actual = self::cu($unserialized);
 
     $this->assertInstanceOf(\Closure::class, $actual);
-    $this->assertEquals('test', $actual());
+    $this->assertSame('test', $actual());
   }
 
 }

--- a/tests/Unit/StringTraitTest.php
+++ b/tests/Unit/StringTraitTest.php
@@ -42,7 +42,6 @@ final class StringTraitTest extends UnitTestCase {
 
     if ($custom_prefixes) {
       if (!$custom_messages) {
-        // Add default messages if custom prefixes but no custom messages.
         $args = array_merge($args, [
           'Expected exact match for "%s" in haystack',
           'Expected substring "%s" in haystack',
@@ -280,7 +279,6 @@ final class StringTraitTest extends UnitTestCase {
       'apple',
       ['+apple'],
       TRUE,
-    // Empty separator.
       ['+', '*', '-', '!', ''],
       ['Expected exact match for "%s" in haystack', 'Expected substring "%s" in haystack', 'Expected no exact match for "%s" in haystack', 'Expected substring "%s" not in haystack'],
       NULL,
@@ -291,7 +289,6 @@ final class StringTraitTest extends UnitTestCase {
       'This contains apple and banana',
       ['*apple', '*banana'],
       TRUE,
-    // Empty separator.
       ['+', '*', '-', '!', ''],
       ['Expected exact match for "%s" in haystack', 'Expected substring "%s" in haystack', 'Expected no exact match for "%s" in haystack', 'Expected substring "%s" not in haystack'],
       NULL,
@@ -302,7 +299,6 @@ final class StringTraitTest extends UnitTestCase {
       'apple',
       ['-orange'],
       TRUE,
-    // Empty separator.
       ['+', '*', '-', '!', ''],
       ['Expected exact match for "%s" in haystack', 'Expected substring "%s" in haystack', 'Expected no exact match for "%s" in haystack', 'Expected substring "%s" not in haystack'],
       NULL,
@@ -313,7 +309,6 @@ final class StringTraitTest extends UnitTestCase {
       'This contains apple and banana',
       ['!orange', '!grape'],
       TRUE,
-    // Empty separator.
       ['+', '*', '-', '!', ''],
       ['Expected exact match for "%s" in haystack', 'Expected substring "%s" in haystack', 'Expected no exact match for "%s" in haystack', 'Expected substring "%s" not in haystack'],
       NULL,
@@ -324,7 +319,6 @@ final class StringTraitTest extends UnitTestCase {
       'test string',
       ['*test', 'string'],
       TRUE,
-    // Empty separator.
       ['+', '*', '-', '!', ''],
       ['Expected exact match for "%s" in haystack', 'Expected substring "%s" in haystack', 'Expected no exact match for "%s" in haystack', 'Expected substring "%s" not in haystack'],
       \RuntimeException::class,
@@ -335,7 +329,6 @@ final class StringTraitTest extends UnitTestCase {
       'test',
       ['+'],
       TRUE,
-    // Empty separator.
       ['+', '*', '-', '!', ''],
       ['Expected exact match for "%s" in haystack', 'Expected substring "%s" in haystack', 'Expected no exact match for "%s" in haystack', 'Expected substring "%s" not in haystack'],
       \RuntimeException::class,

--- a/tests/Unit/StringTraitTest.php
+++ b/tests/Unit/StringTraitTest.php
@@ -19,7 +19,7 @@ final class StringTraitTest extends UnitTestCase {
   public function testAssertStringContainsOrNot(
     string $name,
     string $haystack,
-    string|array $expected,
+    array|string $expected,
     bool $case_insensitive,
     ?array $custom_prefixes,
     ?array $custom_messages,

--- a/tests/Unit/StringTraitTest.php
+++ b/tests/Unit/StringTraitTest.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace AlexSkrypnyk\PhpunitHelpers\Tests\Unit;
 
-use PHPUnit\Framework\AssertionFailedError;
 use AlexSkrypnyk\PhpunitHelpers\Traits\StringTrait;
 use AlexSkrypnyk\PhpunitHelpers\UnitTestCase;
+use PHPUnit\Framework\AssertionFailedError;
 use PHPUnit\Framework\Attributes\CoversTrait;
 use PHPUnit\Framework\Attributes\DataProvider;
 

--- a/tests/Unit/TuiTraitTest.php
+++ b/tests/Unit/TuiTraitTest.php
@@ -104,7 +104,7 @@ final class TuiTraitTest extends TestCase {
     array $expected,
   ): void {
     $keystrokes = self::tuiKeystrokes($entries, $clear_size, $accept_key, $clear_key);
-    $this->assertEquals($expected, $keystrokes);
+    $this->assertSame($expected, $keystrokes);
   }
 
   public static function dataProviderTuiKeystrokes(): \Iterator {

--- a/tests/Unit/TuiTraitTest.php
+++ b/tests/Unit/TuiTraitTest.php
@@ -96,13 +96,7 @@ final class TuiTraitTest extends TestCase {
   }
 
   #[DataProvider('dataProviderTuiKeystrokes')]
-  public function testTuiKeystrokes(
-    array $entries,
-    int $clear_size,
-    ?string $accept_key,
-    ?string $clear_key,
-    array $expected,
-  ): void {
+  public function testTuiKeystrokes(array $entries, int $clear_size, ?string $accept_key, ?string $clear_key, array $expected): void {
     $keystrokes = self::tuiKeystrokes($entries, $clear_size, $accept_key, $clear_key);
     $this->assertSame($expected, $keystrokes);
   }

--- a/tests/Unit/TuiTraitTest.php
+++ b/tests/Unit/TuiTraitTest.php
@@ -206,7 +206,7 @@ final class TuiTraitTest extends TestCase {
         'h', 'e', 'l', 'l', 'o', ' ', 'w', 'o', 'r', 'l', 'd', self::KEYS['ENTER'],
       ],
     ];
-    yield 'string_with_spaces_an_key' => [
+    yield 'string_with_spaces_as_key' => [
       [
         'answer1' => 'hello world',
       ],

--- a/tests/Unit/UnitTestCaseTest.php
+++ b/tests/Unit/UnitTestCaseTest.php
@@ -8,9 +8,6 @@ use AlexSkrypnyk\PhpunitHelpers\Tests\Fixtures\InfoMethodsTrait;
 use AlexSkrypnyk\PhpunitHelpers\UnitTestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
 
-/**
- * Tests for UnitTestCase.
- */
 #[CoversClass(UnitTestCase::class)]
 final class UnitTestCaseTest extends UnitTestCase {
 


### PR DESCRIPTION
## Summary

This is a whole-codebase consistency pass over all 30 first-party files (3,171 lines in `src/`, 6,164 in `tests/`): every file was reviewed, a single canonical form was picked for each inconsistency, and the ones with a clear right answer were applied. 41 inconsistency classes landed across 22 commits, 62 judgment calls are deliberately left for review below, and 1 change was applied and then reverted after it broke a PHPStan check. Tests and lint stayed green after every commit (PHPCS Drupal + DrevOps, PHPStan level 9, Rector).

A 23rd commit fixes a latent bug surfaced during review of this branch - see "Loader validation" below. The suite is now 456 tests, up from 453, because that fix came with three new datasets.

## Changes

Two project-rule violations are fixed outright: `snake_case` method arguments and zero remaining `private` visibility. Two genuine defects are also corrected: `@param` types that contradicted their own signatures, and `TUI_SKIP` typed `null|string` on a value that's always a string.

### Naming

- Renamed 9 camelCase test method arguments in `LoggerTraitTest` to `snake_case` - a project rule, not a preference.
- Converted 26 data provider dataset keys from space-separated phrases to `snake_case`, matching roughly 170 keys already in that style elsewhere.
- Renamed `$counter` to `$count` at 5 sites; the variable holds `count($parts)` as a loop bound and is never incremented.
- Spelled out the `$cmd` abbreviation (`$full_command` in `ProcessTrait`, where `$command` already names a parameter, and `$command` in the functional test).
- Fixed a data provider key typo, `string_with_spaces_an_key` to `as_key`.
- Renamed `testLocationGetters` to `testLocationsGetters` to match its 16 sibling `testLocations*` methods, and shortened `testLocationsFixtureDirThrowsExceptionWhenFixturesDirectoryMissing` to end in `...FixturesDirMissing`.
- Aligned the one `Process should be initialized` guard message with the 20 sibling `<Subject> is not initialized` messages.

### Structure and imports

- Sorted import blocks alphabetically in the 5 test files that weren't; the other 10 test files and all 11 `src/` files already were.
- Sorted trait composition order in `UnitTestCase` to match its own alphabetical import block.

### API shape

- Changed 11 `private` members to `protected` across 3 test files, per the project rule. All classes are `final`, so this is behavior-preserving, and zero `private` remains anywhere in the codebase now.
- Converted 25 `assertEquals` calls to `assertSame` after checking each site's types by hand. One stayed as `assertEquals`: `TuiTraitTest:27` compares an `int`, `float` and `bool` against string expectations, and `tuiEntries()` never casts, so the loose comparison is load-bearing there.
- Corrected 2 `@param` types that contradicted their own signatures: `ProcessTrait:473` and `:500` documented `@param string $expected` where the signature declares `array|string`.
- Corrected `TUI_SKIP`'s docblock from `@var null|string` to `@var string`; its value is the literal `'__SKIP__'`.
- Added 13 missing `@throws` annotations, 8 missing `@return` annotations, 1 missing `@param` (on `envIsUnset()`), and 3 missing `@mixin \PHPUnit\Framework\TestCase` annotations.
- Normalized union type notation: unspaced 7 occurrences of `array | string` and reordered 15 sites to `array|string` consistently.
- Unified nullable `@param` notation on `?string` (18 sites already used it, 2 didn't).
- Added native parameter types to `setProtectedValue()`/`getProtectedValue()`, the only untyped signatures left in `src/`, and typed the streaming closure parameters as `(string $type, string $buffer)`.
- Converted 3 double-quoted string literals with no single quote inside to single quotes, per the project rule.
- Changed `self::KEYS` to `static::KEYS` at the one site that diverged from its 3 siblings in a trait meant for subclass overriding, and changed `public const KEYS` to a bare `const` to match its 4 sibling constants.
- Changed 42 `$this->env*` calls in `EnvTraitTest` to `self::env*`, since every `EnvTrait` method is static.
- Replaced a raw `realpath()` call with the trait's own `locationsRealpath()`.
- Renamed `$expected_exception` to `$expected_exception_message` at 24 sites; the parameter holds a message substring, not a class name.
- Converted one concatenated failure message to `sprintf` to match its 4 siblings, and collapsed 3 wrapped signatures to single lines (all were well under the project's 160-character limit).

### Architecture

- Converted 4 `=== NULL` initialization guards to `!$x instanceof Class`, matching the project rule's own example.
- Hoisted `new Filesystem()` out of a per-file copy loop in `locationsCopy()`.
- Collapsed a duplicated `if`/`else` in `logSection()` where both branches assigned the same `$header_format`.
- Gave 2 arrays an explicit `$lines = []` initialization before their first append.
- Fixed `LoggerTraitFunctionalTest::setUp()` to also reset `$loggerStepStack`; it was only resetting `$loggerSteps` and leaking stack state between tests.
- Flipped `tearDown()` ordering in `ProcessTraitScenariosTest` to clean up before calling the parent, matching 5 sibling files and stopping the process before the parent removes its workspace.
- Added missing `parent::setUp()`/`parent::tearDown()` calls, and removed 4 redundant `addToAssertionCount()` calls from tests that already assert.
- Removed a dead `tempnam()` call whose return value was discarded (leaking a temp file per run) and a leftover debug `echo`.

### Loader validation

- `applicationInitFromLoader()` assigned the `require` result straight to the typed `?Application $application` property, so a loader returning any non-null wrong type raised `TypeError` at the assignment and the `instanceof` guard below it was unreachable. The documented `@throws \InvalidArgumentException` did not hold for that path.
- The result is now stored in a local, validated, and only then assigned.
- This matters for this branch specifically: the `@throws` annotation on that method was added here, so leaving the code unchanged would have shipped an annotation documenting a contract the code does not honour.
- `testApplicationInitFromLoaderInvalidReturn` is now a data provider covering `null`, `new \stdClass()`, a scalar and an array. With the fix reverted, 3 of those 4 datasets fail with `TypeError`; the original `null` case passes either way, which is why the gap went unnoticed.

### Comment register

- Ran a separate pass over source comments once the naming and API commits had settled the symbol names: 339 comments deleted, 53 rewritten, 277 left alone.
- Every changed line in that pass is a comment, a docblock, or a blank line - no code line was touched.
- Deleting outweighed rewriting, which is the point: most of what came out was narration restating the next line of code.
- `phpcs.xml` applies `Drupal.Commenting` to `src/` and to non-test files under `tests/`, which requires a docblock on every class, property and method, so some docblocks that only restate a symbol's name stay in place rather than trip lint.

## Comments found to be incorrect (not fixed here)

24 comments document behavior the code doesn't actually have. These are documentation bugs, not wording problems, so fixing any of them changes what the docs claim about behavior - that's a call for a reviewer, not something to fold quietly into a comment cleanup. None of these were touched.

Public API documentation that's simply wrong:

- `LocationsTrait::locationsCopy()` says an empty `$include` means "no files will be copied." It's the opposite: an empty `$include` makes the Finder filter return `TRUE` for every file, so everything under `$src` gets copied.
- `LocationsTrait::locationsCopyFilesToSut()` says `$basedir` falls back to "the base directory of the first file." It actually falls back to `getcwd()` - the first file's directory is never used.
- `LocationsTrait::locationsTearDown()` claims it "will be skipped if the DEBUG environment variable is set." The method has no such check and unconditionally removes the workspace; the skip actually lives in the caller, `UnitTestCase::tearDown()`.
- `LoggerTrait::loggerInfo()`'s `@return` reads "The locations' info," copied from `LocationsTrait::locationsInfo()`. It returns the logger step summary.
- `ReflectionTrait::getProtectedValue()` documents `$object` as "Object to set the value on," copied from the setter. It reads.
- `UnitTestCase::info()` says it collects "all methods in the class that end with 'Info'." It also excludes any method whose name contains `test`, so that's not quite accurate.
- `AssertArrayTrait`'s docblock summary read "Trait AssertTrait" - the wrong trait name entirely.
- `locationsRealpath()` is summarized as getting "the real path of a directory." It resolves any path and is called on file paths too.
- `LocationsTrait`'s own docblock names it "Trait Locations" instead of `LocationsTrait`.
- `EnvTrait::envUnsetPrefix()` is summarized in the singular ("Unset an environment variable by prefix") but unsets every matching variable.
- `SerializableClosureTrait::cw()` documents `$callable` as "The closure to wrap"; it accepts any callable and converts non-Closures first.
- 3 `@return`/summary lines describe `locationsInfo()`, `loggerInfo()` and `applicationInfo()` as printing. All three build and return a string and write nothing.

Comments describing behavior the code doesn't have:

- `ProcessTrait::processParseCommand()` documents that the `--` end-of-options marker "stops option parsing and treats all subsequent tokens as positional arguments." `$end_of_options_found` never changes how later tokens are split, and the parser doesn't distinguish options from positionals anywhere, so tokenization is identical with or without that branch. This reads as dead code behind a documented feature.
- `ProcessTrait`'s `$process` property and `processGet()` describe "the currently running process." `Process::run()` is synchronous, so the process has already exited by the time either is reachable; `processRun()`'s own `@return` correctly calls it "The completed process."
- 3 comments in `ProcessTraitTest` claim `processStreamingOutputCallback()` is overridden, or that the test "uses the actual processRun method." The tests construct a `Symfony\Process` directly and duplicate the callback in a local closure - neither claim is true.
- `LoggerTraitTest:595` says a `getCapturedOutput()` call clears leaked output. The method only rewinds and reads; it never truncates, and the buffer gets replaced two lines later.
- `ApplicationTraitTest:76` says the working directory "can't be checked directly because it's reset by the shutdown function." The shutdown function runs at process shutdown, not during the test, and `testApplicationInitFromLoaderWithWorkingDirectory` in the same file asserts it directly anyway.
- `ApplicationTraitTest:675` explains an assertion passes "because there is content after the newline." The literal is single-quoted, so it holds a backslash-n, not an actual newline - the assertion passes for an unrelated reason.
- `ApplicationTrait:218`'s comment "Expected to succeed, but failed." labels a branch that throws for any non-zero exit code, regardless of `$expect_fail`.

## Bugs found (not fixed here)

Found while checking the comment claims above. None of these were touched - they all need a decision:

- `ApplicationTrait::applicationRun()` has an expectation path that can never fail a test. When the application succeeds but `$expect_fail` is `TRUE`, line 215 throws `AssertionFailedError`, which PHPUnit derives from `\RuntimeException`. The method's own `catch (\RuntimeException)` at line 218 swallows that exception and, because `$expect_fail` is `TRUE`, turns it into returned output instead. The "expected failure but succeeded" case silently passes.
- `testApplicationInitFromLoaderWithGetcwdFailure` doesn't test what its name says. Nothing is mocked, `getcwd()` returns a real path, and the `getcwd() === FALSE` guard it claims to cover never runs.
- `LoggerTraitFunctionalTest` misuses `logStepSummary()` at two sites, passing a title string into the `$indent` parameter and discarding the returned table - which suggests the `log`-prefixed name is misleading, since every sibling `log*` method writes to the stream.
- 2 pairs of near-duplicate tests: `testProcessFormatOutputWhenNotInitialized` and `testProcessFormatOutputWithoutProcessInstance` cover the same scenario, and `testLogStepSummaryWithNoSteps` / `testLogStepSummaryEmpty` differ only subtly - the latter pair looks vestigial since `logStepSummary()` never writes to the stream.
- `ApplicationTrait` composes `ReflectionTrait` but never calls any of its members. Removing the `use` isn't a safe cleanup on its own - it would strip `callProtectedMethod()` and friends from every consumer that composes `ApplicationTrait`, which is a transitive API removal.
- `ProcessTrait` calls `$this->assertionSuffix()` at 20 sites but neither declares it nor composes a trait that provides it. It only compiles when mixed into a class that supplies it (`UnitTestCase`). Worth either an abstract declaration or explicit documentation of the requirement.

One change was applied and then reverted: adding `@var array<int, array<string, mixed>>` to `LoggerTrait::$loggerSteps` broke 12 PHPStan level 9 checks. PHPStan already infers a precise shape for that property from its assignments, and the coarser annotation overrode that inference, turning typed element access into `mixed`. The missing annotation turned out to be load-bearing, so that change was dropped rather than worked around.

## Judgment calls left for the reviewer (62)

Nothing in this section was applied.

### Public symbol renames (24)

Every trait method, property and constant in `src/` is documented in the README and composed into consumer test classes, so renaming any of them breaks anyone who `composer require`s this library. The convergence opportunities are real, but they need a maintainer's call, not a blanket rename. The largest one: `LoggerTrait` mixes 3 method-prefix schemes in one trait (`logger*` on 3 methods, `log*` on 8, unprefixed on 2), while `LocationsTrait`, `TuiTrait` and `EnvTrait` each commit to exactly one. Also deferred: `dim()` as the only unprefixed member of `ProcessTrait`; `cw()`/`cu()` as 2-letter names sitting among 25 descriptive ones; `Stream` vs `Streaming` inside one trait's property names; `$processStreamOutput` vs `$applicationShowOutput` naming the same concept across parallel traits; and needle-first vs container-first argument order across the assertion families.

### Behavior changes (19)

Converging any of these would change what the code does, so none of them were touched here. Highlights: which exception class signals a missing path (`InvalidArgumentException` vs `RuntimeException`); whether a caller's `$message` gets forwarded into uninitialized-subject guards (`ApplicationTrait` forwards it at 9 of 9 sites, `ProcessTrait` ignores it at 11 of 11); whether `assertionSuffix()` gets appended to failure messages (`ProcessTrait` 20 of 20, `ApplicationTrait` 0 of 9); the deeper design split between `processRun()` (returns the failed process, swallows exceptions) and `applicationRun()` (takes `$expect_fail`, throws); and whether the 6 plain-`TestCase` suites should extend `UnitTestCase` instead, which would add real filesystem I/O to every test in them.

### Genuine ties (8)

No project rule, no clear majority, no idiom that settles it. Trailing punctuation on failure messages splits roughly 10-10. `Cwd` vs `WorkingDirectory` points different ways depending on whether you count test names (3-1 for `WorkingDirectory`) or align with the `src` API (`$processCwd`, `$applicationCwd`). Provider dataset element style splits 4 positional to 5 associative, and both are idiomatic here.

### Docs and refactor polish (11)

Left for a separate documentation/refactor pass rather than handled here. The highest-value one is the project's own rule to prefer data providers over repeated near-identical test methods: `EnvTraitTest` has 8 longhand methods with near-identical setups, and `ProcessTraitTest` has 11 `WhenNull` clones sharing one skeleton. That's a test-suite redesign, not a mechanical rewrite.

## Before / After

```
┌─ BEFORE ─────────────────────────────────────────────────────┐
│  naming      camelCase args beside snake_case args           │
│  keys        dataset keys as free-text phrases               │
│  visibility  11 private members in test classes              │
│  types       "array | string" beside "string|array"          │
│  docs        2 @param types contradicted their signatures    │
│  constants   TUI_SKIP documented as null|string              │
│  loader      wrong return type raised TypeError, not the     │
│              documented InvalidArgumentException             │
│  comments    669 comments, many narrating the next line      │
└──────────────────────────────────────────────────────────────┘
                               │
                               ▼
┌─ AFTER ──────────────────────────────────────────────────────┐
│  naming      snake_case args everywhere                      │
│  keys        snake_case dataset keys everywhere              │
│  visibility  0 private members repo-wide                     │
│  types       array|string, one spelling, one order           │
│  docs        0 known @param type contradictions              │
│  constants   TUI_SKIP documented as string                   │
│  loader      validated before assignment, so the documented  │
│              InvalidArgumentException actually fires         │
│  comments    330 comments, each earning its place            │
└──────────────────────────────────────────────────────────────┘
```
