### PR TITLE
Punctuated two 'ApplicationTrait' messages and covered the assertions that hid the drift.

### DIFF
--- a/src/Traits/ApplicationTrait.php
+++ b/src/Traits/ApplicationTrait.php
@@ -499,7 +499,7 @@ trait ApplicationTrait {
    *   Optional failure message.
    */
   public function assertApplicationAnyOutputContains(array|string $expected, ?string $message = NULL): void {
-    $this->assertNotNull($this->applicationTester, $message ?: 'Application is not initialized');
+    $this->assertNotNull($this->applicationTester, $message ?: 'Application is not initialized.');
     $output = $this->applicationTester->getDisplay() . $this->applicationTester->getErrorOutput();
 
     $expected = is_array($expected) ? $expected : [$expected];
@@ -526,7 +526,7 @@ trait ApplicationTrait {
    *   Optional failure message.
    */
   public function assertApplicationAnyOutputNotContains(array|string $expected, ?string $message = NULL): void {
-    $this->assertNotNull($this->applicationTester, $message ?: 'Application is not initialized');
+    $this->assertNotNull($this->applicationTester, $message ?: 'Application is not initialized.');
     $output = $this->applicationTester->getDisplay() . $this->applicationTester->getErrorOutput();
 
     $expected = is_array($expected) ? $expected : [$expected];

--- a/tests/Unit/ApplicationTraitTest.php
+++ b/tests/Unit/ApplicationTraitTest.php
@@ -472,85 +472,33 @@ final class ApplicationTraitTest extends UnitTestCase {
     $this->assertStringContainsString('APPLICATION: Not initialized', $info);
   }
 
-  public function testAssertApplicationSuccessfulWhenNull(): void {
+  #[DataProvider('dataProviderAssertionsWhenNull')]
+  public function testAssertionsWhenNull(string $method, array $arguments): void {
     $this->applicationTester = NULL;
 
     $this->expectException(ExpectationFailedException::class);
     $this->expectExceptionMessage('Application is not initialized.');
 
-    $this->assertApplicationSuccessful();
+    $callable = [$this, $method];
+    if (!is_callable($callable)) {
+      throw new \RuntimeException(sprintf('Assertion method %s does not exist.', $method));
+    }
+
+    $callable(...$arguments);
   }
 
-  public function testAssertApplicationFailedWhenNull(): void {
-    $this->applicationTester = NULL;
-
-    $this->expectException(ExpectationFailedException::class);
-    $this->expectExceptionMessage('Application is not initialized.');
-
-    $this->assertApplicationFailed();
-  }
-
-  public function testAssertApplicationOutputContainsWhenNull(): void {
-    $this->applicationTester = NULL;
-
-    $this->expectException(ExpectationFailedException::class);
-    $this->expectExceptionMessage('Application is not initialized.');
-
-    $this->assertApplicationOutputContains('test');
-  }
-
-  public function testAssertApplicationOutputNotContainsWhenNull(): void {
-    $this->applicationTester = NULL;
-
-    $this->expectException(ExpectationFailedException::class);
-    $this->expectExceptionMessage('Application is not initialized.');
-
-    $this->assertApplicationOutputNotContains('test');
-  }
-
-  public function testAssertApplicationErrorOutputContainsWhenNull(): void {
-    $this->applicationTester = NULL;
-
-    $this->expectException(ExpectationFailedException::class);
-    $this->expectExceptionMessage('Application is not initialized.');
-
-    $this->assertApplicationErrorOutputContains('test');
-  }
-
-  public function testAssertApplicationErrorOutputNotContainsWhenNull(): void {
-    $this->applicationTester = NULL;
-
-    $this->expectException(ExpectationFailedException::class);
-    $this->expectExceptionMessage('Application is not initialized.');
-
-    $this->assertApplicationErrorOutputNotContains('test');
-  }
-
-  public function testAssertApplicationOutputContainsOrNotWhenNull(): void {
-    $this->applicationTester = NULL;
-
-    $this->expectException(ExpectationFailedException::class);
-    $this->expectExceptionMessage('Application is not initialized.');
-
-    $this->assertApplicationOutputContainsOrNot('test');
-  }
-
-  public function testAssertApplicationErrorOutputContainsOrNotWhenNull(): void {
-    $this->applicationTester = NULL;
-
-    $this->expectException(ExpectationFailedException::class);
-    $this->expectExceptionMessage('Application is not initialized.');
-
-    $this->assertApplicationErrorOutputContainsOrNot('test');
-  }
-
-  public function testAssertApplicationAnyOutputContainsOrNotWhenNull(): void {
-    $this->applicationTester = NULL;
-
-    $this->expectException(ExpectationFailedException::class);
-    $this->expectExceptionMessage('Application is not initialized.');
-
-    $this->assertApplicationAnyOutputContainsOrNot('test');
+  public static function dataProviderAssertionsWhenNull(): \Iterator {
+    yield 'successful' => ['assertApplicationSuccessful', []];
+    yield 'failed' => ['assertApplicationFailed', []];
+    yield 'output_contains' => ['assertApplicationOutputContains', ['test']];
+    yield 'output_not_contains' => ['assertApplicationOutputNotContains', ['test']];
+    yield 'error_output_contains' => ['assertApplicationErrorOutputContains', ['test']];
+    yield 'error_output_not_contains' => ['assertApplicationErrorOutputNotContains', ['test']];
+    yield 'output_contains_or_not' => ['assertApplicationOutputContainsOrNot', ['test']];
+    yield 'error_output_contains_or_not' => ['assertApplicationErrorOutputContainsOrNot', ['test']];
+    yield 'any_output_contains' => ['assertApplicationAnyOutputContains', ['test']];
+    yield 'any_output_not_contains' => ['assertApplicationAnyOutputNotContains', ['test']];
+    yield 'any_output_contains_or_not' => ['assertApplicationAnyOutputContainsOrNot', ['test']];
   }
 
   public function testApplicationAnyOutputErrorCommandAssertions(): void {


### PR DESCRIPTION
## Summary

Two `ApplicationTrait` assertions report `Application is not initialized` without a trailing period, while the other ten report `Application is not initialized.` with one. This settles the two outliers and adds the test coverage whose absence let them drift.

The gap is an artifact of ordering. `assertApplicationAnyOutputContains()` and `assertApplicationAnyOutputNotContains()` were added in #114, while the punctuation convention was settled in #116 against the methods that existed at the time. The two new methods were never covered by either change, and no test asserted their uninitialized-state message, so nothing caught it.

## Changes

**Punctuation.** Both methods now end their uninitialized-state message with a period, matching the other ten assertion methods in the trait. These are the only two unpunctuated messages left in `src/`.

**Coverage.** `ApplicationTraitTest` had nine near-identical `WhenNull` methods, each nulling the tester and expecting the same failure from a different assertion, and neither new method had one. They are now a single provider-driven test covering all eleven assertions, including the two that had none. This is the shape `ProcessTraitTest` already uses after #118.

## Verification

Reverting the source fix while keeping the tests fails exactly the two new datasets:

```
1) ApplicationTraitTest::testAssertionsWhenNull@any_output_contains
Failed asserting that exception message 'Application is not initialized
Failed asserting that null is not null.' contains 'Application is not initialized.'.

2) ApplicationTraitTest::testAssertionsWhenNull@any_output_not_contains
Failed asserting that exception message 'Application is not initialized
Failed asserting that null is not null.' contains 'Application is not initialized.'.
```

## Test plan

- [x] `composer test` green: 474 tests
- [x] `composer lint` green: PHPCS, PHPStan level 9, Rector
- [x] Confirmed the two new datasets fail without the source fix and pass with it
- [x] Confirmed no other message in `src/` is missing its final period

## Before / After

```
┌─ BEFORE ─────────────────────────────────────────────────────┐
│  ApplicationTrait uninitialized message                      │
│    10 sites   'Application is not initialized.'              │
│     2 sites   'Application is not initialized'               │
│                 assertApplicationAnyOutputContains           │
│                 assertApplicationAnyOutputNotContains        │
│                                                              │
│  ApplicationTraitTest WhenNull coverage                      │
│     9 near-identical methods, one per assertion              │
│     2 assertions with no WhenNull test at all                │
│       - the same two that drifted                            │
└──────────────────────────────────────────────────────────────┘
                               │
                               ▼
┌─ AFTER ──────────────────────────────────────────────────────┐
│  ApplicationTrait uninitialized message                      │
│    12 sites   'Application is not initialized.'              │
│                                                              │
│  ApplicationTraitTest WhenNull coverage                      │
│     1 test + provider, 11 assertions covered                 │
│       - the drift now fails a test                           │
└──────────────────────────────────────────────────────────────┘
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Fixed swallowed expected-failure assertions in `applicationRun()`.
- Made `--` handling effective in `processRun()`.
- Corrected `locationsRealpath()` error messages and expanded loader coverage.
- Renamed public trait members and removed transitive `ReflectionTrait` composition.
- Added combined application output assertions.
- Clarified assertion contracts, exception types, failure messages, and documentation.
- Streamlined regression tests and expanded coverage for expected failures and output assertions.

## Validation

- 465 tests passed.
- 1,402 assertions passed.
- Linting, static analysis, and Rector checks passed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->