### PR TITLE
Split path exceptions by cause and fixed the empty path in the message.

### DIFF
--- a/src/Traits/ApplicationTrait.php
+++ b/src/Traits/ApplicationTrait.php
@@ -209,6 +209,7 @@ trait ApplicationTrait {
     $options += ['capture_stderr_separately' => TRUE];
 
     $output = '';
+    $succeeded_unexpectedly = FALSE;
     try {
       $this->applicationTester->run($input, $options);
       $output = $this->applicationTester->getDisplay();
@@ -219,14 +220,18 @@ trait ApplicationTrait {
         // @codeCoverageIgnoreEnd
       }
 
-      // Expected to succeed, but failed.
       if ($this->applicationTester->getStatusCode() !== 0) {
-        throw new \Exception(sprintf("Application exited with non-zero code.\nThe output was:\n%s\nThe error output was:\n%s", $this->applicationTester->getDisplay(), $this->applicationTester->getErrorOutput()));
+        // An expected failure keeps the application output; only an unexpected
+        // one is converted into a diagnostic by the catch blocks below.
+        if (!$expect_fail) {
+          throw new \Exception(sprintf("Application exited with non-zero code.\nThe output was:\n%s\nThe error output was:\n%s", $this->applicationTester->getDisplay(), $this->applicationTester->getErrorOutput()));
+        }
       }
-
-      // Expected to fail, but succeeded.
-      if ($expect_fail) {
-        throw new AssertionFailedError(sprintf("Application exited successfully but should not.\nThe output was:\n%s\nThe error output was:\n%s", $this->applicationTester->getDisplay(), $this->applicationTester->getErrorOutput()));
+      // AssertionFailedError descends from \RuntimeException, so throwing it
+      // here would be caught below. Record the outcome and throw after the
+      // catch blocks instead.
+      elseif ($expect_fail) {
+        $succeeded_unexpectedly = TRUE;
       }
     }
     catch (\RuntimeException $exception) {
@@ -244,6 +249,10 @@ trait ApplicationTrait {
       }
       // Expected to fail, so capture the output.
       $output = $exception->getMessage();
+    }
+
+    if ($succeeded_unexpectedly) {
+      throw new AssertionFailedError(sprintf("Application exited successfully but should not.\nThe output was:\n%s\nThe error output was:\n%s", $this->applicationTester->getDisplay(), $this->applicationTester->getErrorOutput()));
     }
 
     // Error output is captured separately, so append it to the output.

--- a/src/Traits/LocationsTrait.php
+++ b/src/Traits/LocationsTrait.php
@@ -284,13 +284,13 @@ trait LocationsTrait {
    * @return array<int, string>
    *   The list of created file paths.
    *
-   * @throws \RuntimeException
-   *   When the base directory does not exist.
+   * @throws \InvalidArgumentException
+   *   When the base path is not a directory.
    */
   public static function locationsCopyFilesToSut(array $files, ?string $basedir = NULL, bool $append_rand = TRUE): array {
     $basedir = $basedir ?: getcwd();
     if (!$basedir || !is_dir($basedir)) {
-      throw new \RuntimeException(sprintf('The base directory "%s" does not exist.', $basedir));
+      throw new \InvalidArgumentException(sprintf('The base path "%s" is not a directory.', $basedir));
     }
     return static::locationsCopy($basedir, static::$sut, $files, [], function (string &$src, string &$dst) use ($append_rand): void {
       $dst .= ($append_rand ? random_int(1000, 9999) : '');
@@ -323,18 +323,18 @@ trait LocationsTrait {
    * @return string
    *   The real path.
    *
-   * @throws \RuntimeException
+   * @throws \InvalidArgumentException
    *   If the path does not exist.
    */
   public static function locationsRealpath(string $path): string {
-    $path = realpath($path);
+    $resolved = realpath($path);
 
     // @codeCoverageIgnoreStart
-    if ($path === FALSE) {
-      throw new \RuntimeException(sprintf('Path "%s" does not exist.', $path));
+    if ($resolved === FALSE) {
+      throw new \InvalidArgumentException(sprintf('Path "%s" does not exist.', $path));
     }
     // @codeCoverageIgnoreEnd
-    return $path;
+    return $resolved;
   }
 
   /**

--- a/src/Traits/ProcessTrait.php
+++ b/src/Traits/ProcessTrait.php
@@ -104,7 +104,9 @@ trait ProcessTrait {
    *   The command to run. Can be a single command or command with arguments
    *   separated by spaces (e.g., "git status" or "ls -la").
    * @param array $arguments
-   *   Additional command arguments.
+   *   Additional command arguments. When the command string contains an
+   *   end-of-options marker (--), these are inserted before it so they keep
+   *   their option meaning.
    *   Note: All scalar arguments are converted to strings (TRUE→"1", FALSE→"").
    * @param array $inputs
    *   Array of inputs for interactive processes.
@@ -133,11 +135,29 @@ trait ProcessTrait {
     $base_command = array_shift($parsed_command);
     $parsed_arguments = $parsed_command;
 
+    // @codeCoverageIgnoreStart
+    if ($base_command === NULL) {
+      throw new \InvalidArgumentException('Command cannot be empty.');
+    }
+    // @codeCoverageIgnoreEnd
     if (preg_match('/[^a-zA-Z0-9_\-.\/]/', $base_command)) {
       throw new \InvalidArgumentException(sprintf('Invalid command: %s. Only alphanumeric characters, dots, dashes, underscores and slashes are allowed.', $base_command));
     }
 
-    $all_arguments = array_values(array_merge($parsed_arguments, $arguments));
+    // Everything after the end-of-options marker is positional, so appending
+    // there would strip the option meaning from caller-supplied arguments.
+    $marker_position = array_search('--', $parsed_arguments, TRUE);
+    if ($marker_position === FALSE) {
+      $all_arguments = array_merge($parsed_arguments, $arguments);
+    }
+    else {
+      $all_arguments = array_merge(
+        array_slice($parsed_arguments, 0, $marker_position),
+        $arguments,
+        array_slice($parsed_arguments, $marker_position)
+      );
+    }
+    $all_arguments = array_values($all_arguments);
 
     foreach ($all_arguments as &$arg) {
       if (!is_scalar($arg)) {
@@ -192,9 +212,10 @@ trait ProcessTrait {
    * Parses a command string into command and arguments.
    *
    * Handles quoted arguments and escaping properly. Supports both single
-   * and double quotes. Also supports the end-of-options marker (--) which
-   * stops option parsing and treats all subsequent tokens as positional
-   * arguments.
+   * and double quotes. The end-of-options marker (--) is emitted as an
+   * ordinary token: the parser draws no option/positional distinction, and
+   * the target program interprets the marker. processRun() places
+   * caller-supplied arguments before it.
    *
    * The parser deliberately allows backslash escaping inside single quotes
    * (e.g., 'It\'s working'). POSIX shells treat backslashes inside single
@@ -204,7 +225,7 @@ trait ProcessTrait {
    * @param string $command
    *   The command string to parse.
    *
-   * @return array
+   * @return list<string>
    *   Array with command as first element and arguments as subsequent elements.
    *
    * @throws \InvalidArgumentException
@@ -223,7 +244,6 @@ trait ProcessTrait {
     $escaped = FALSE;
     $length = strlen($command);
     $has_content = FALSE;
-    $end_of_options_found = FALSE;
 
     for ($i = 0; $i < $length; $i++) {
       $char = $command[$i];
@@ -255,15 +275,6 @@ trait ProcessTrait {
 
       if (!$in_quotes && ($char === ' ' || $char === "\t")) {
         if ($current !== '' || $has_content) {
-          if (!$end_of_options_found && $current === '--') {
-            $end_of_options_found = TRUE;
-            // Keep the -- marker so the command receives it.
-            $parts[] = $current;
-            $current = '';
-            $has_content = FALSE;
-            continue;
-          }
-
           $parts[] = $current;
           $current = '';
           $has_content = FALSE;

--- a/tests/Fixtures/argv-echo.sh
+++ b/tests/Fixtures/argv-echo.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+##
+# Prints every received argument on its own line, prefixed by its position.
+#
+# @usage: ./argv-echo.sh --flag -- positional
+
+set -e
+
+position=0
+for arg in "$@"; do
+  position=$((position + 1))
+  echo "ARGV[${position}]=${arg}"
+done

--- a/tests/Functional/ProcessTraitArgumentsTest.php
+++ b/tests/Functional/ProcessTraitArgumentsTest.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AlexSkrypnyk\PhpunitHelpers\Tests\Functional;
+
+use AlexSkrypnyk\PhpunitHelpers\Traits\ProcessTrait;
+use AlexSkrypnyk\PhpunitHelpers\UnitTestCase;
+use PHPUnit\Framework\Attributes\CoversTrait;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+/**
+ * Asserts argument placement by inspecting a real subprocess argv.
+ */
+#[CoversTrait(ProcessTrait::class)]
+final class ProcessTraitArgumentsTest extends UnitTestCase {
+
+  use ProcessTrait;
+
+  protected function setUp(): void {
+    parent::setUp();
+    $this->processStreamOutput = FALSE;
+  }
+
+  protected function tearDown(): void {
+    $this->processTearDown();
+    parent::tearDown();
+  }
+
+  #[DataProvider('dataProviderArgumentPlacement')]
+  public function testArgumentPlacement(string $suffix, array $arguments, array $expected): void {
+    if (DIRECTORY_SEPARATOR === '\\') {
+      $this->markTestSkipped('Requires POSIX utilities');
+    }
+
+    if (!self::$fixtures) {
+      throw new \RuntimeException('Fixtures directory is not set.');
+    }
+
+    $this->processRun(self::$fixtures . '/argv-echo.sh' . $suffix, $arguments);
+
+    $this->assertProcessSuccessful();
+    $this->assertProcessOutputContains($expected);
+
+    $output = $this->processGet()->getOutput();
+    $this->assertSame(count($expected), substr_count($output, 'ARGV['), 'Subprocess received exactly the expected number of arguments.');
+  }
+
+  public static function dataProviderArgumentPlacement(): \Iterator {
+    yield 'no_marker_arguments_appended' => [
+      ' --flag',
+      ['extra'],
+      ['ARGV[1]=--flag', 'ARGV[2]=extra'],
+    ];
+    yield 'marker_arguments_inserted_before_it' => [
+      ' -- positional',
+      ['--flag'],
+      ['ARGV[1]=--flag', 'ARGV[2]=--', 'ARGV[3]=positional'],
+    ];
+    yield 'marker_first_token_arguments_lead' => [
+      ' -- -abc',
+      ['--extra'],
+      ['ARGV[1]=--extra', 'ARGV[2]=--', 'ARGV[3]=-abc'],
+    ];
+    yield 'marker_with_options_before_it' => [
+      ' -v -- --dry-run',
+      ['--extra'],
+      ['ARGV[1]=-v', 'ARGV[2]=--extra', 'ARGV[3]=--', 'ARGV[4]=--dry-run'],
+    ];
+    yield 'only_first_marker_is_the_boundary' => [
+      ' -- first -- second',
+      ['--extra'],
+      ['ARGV[1]=--extra', 'ARGV[2]=--', 'ARGV[3]=first', 'ARGV[4]=--', 'ARGV[5]=second'],
+    ];
+    yield 'marker_without_arguments_passes_through' => [
+      ' -- positional',
+      [],
+      ['ARGV[1]=--', 'ARGV[2]=positional'],
+    ];
+    yield 'quoted_marker_is_not_a_boundary' => [
+      ' "-- quoted" tail',
+      ['--extra'],
+      ['ARGV[1]=-- quoted', 'ARGV[2]=tail', 'ARGV[3]=--extra'],
+    ];
+  }
+
+}

--- a/tests/Unit/ApplicationTraitTest.php
+++ b/tests/Unit/ApplicationTraitTest.php
@@ -181,6 +181,38 @@ final class ApplicationTraitTest extends UnitTestCase {
     $this->assertApplicationOutputContains('Hello, TestUser!');
   }
 
+  public function testApplicationRunExpectedFailureReturnsOutput(): void {
+    $command = new class() extends Command {
+
+      protected function configure(): void {
+        $this->setName('test:exit-code');
+      }
+
+      protected function execute(InputInterface $input, OutputInterface $output): int {
+        $output->writeln('Important output line');
+
+        return Command::FAILURE;
+      }
+
+    };
+
+    $this->applicationInitFromCommand($command);
+
+    $output = $this->applicationRun([], [], TRUE);
+
+    $this->assertStringContainsString('Important output line', $output);
+    $this->assertStringNotContainsString('Application exited with non-zero code', $output);
+  }
+
+  public function testApplicationRunExpectedFailureButSucceeded(): void {
+    $this->applicationInitFromCommand(GreetingCommand::class);
+
+    $this->expectException(AssertionFailedError::class);
+    $this->expectExceptionMessage('Application exited successfully but should not.');
+
+    $this->applicationRun([], [], TRUE);
+  }
+
   public function testApplicationRunExceptionHandling(): void {
     $this->application = new Application();
 

--- a/tests/Unit/LocationsTraitTest.php
+++ b/tests/Unit/LocationsTraitTest.php
@@ -227,6 +227,33 @@ class LocationsTraitTest extends TestCase {
     }
   }
 
+  #[DataProvider('dataProviderLocationsCopyFilesToSutInvalidBasedir')]
+  public function testLocationsCopyFilesToSutInvalidBasedir(string $type): void {
+    $this->locationsInit($this->testCwd);
+
+    $basedir = $this->testTmp . DIRECTORY_SEPARATOR . 'not_a_directory';
+    if ($type === 'file') {
+      file_put_contents($basedir, 'This is a file, not a directory.');
+    }
+
+    $this->expectException(\InvalidArgumentException::class);
+    $this->expectExceptionMessage('is not a directory.');
+
+    try {
+      self::locationsCopyFilesToSut([], $basedir);
+    }
+    finally {
+      if (is_file($basedir)) {
+        unlink($basedir);
+      }
+    }
+  }
+
+  public static function dataProviderLocationsCopyFilesToSutInvalidBasedir(): \Iterator {
+    yield 'missing_path' => ['missing'];
+    yield 'existing_file' => ['file'];
+  }
+
   public function testLocationsTearDown(): void {
     self::$workspace = $this->testTmp . DIRECTORY_SEPARATOR . 'test_workspace_' . uniqid();
     mkdir(self::$workspace, 0777, TRUE);

--- a/tests/Unit/ProcessTraitTest.php
+++ b/tests/Unit/ProcessTraitTest.php
@@ -912,8 +912,7 @@ EOL;
   }
 
   public function testProcessRunExplicitArgumentsPrecedence(): void {
-    // Explicit arguments are appended after parsed ones to preserve command
-    // structure, especially -- markers.
+    // Without an end-of-options marker, explicit arguments are appended.
     $this->processRun('echo default-arg1 default-arg2', ['override-arg1', 'override-arg2']);
 
     $this->assertProcessSuccessful();
@@ -924,7 +923,7 @@ EOL;
     $this->processRun('echo command -- after-marker', ['explicit']);
 
     $this->assertProcessSuccessful();
-    $this->assertProcessOutputContains('command -- after-marker explicit');
+    $this->assertProcessOutputContains('command explicit -- after-marker');
   }
 
   public function testProcessRunWithIdleTimeout(): void {


### PR DESCRIPTION
> Stacked on #103. Review that one first; this PR's diff is only its own change.

## Summary

`LocationsTrait` raised `RuntimeException` for a bad path the caller supplied, while `LoggerTrait::logFile()` raised `InvalidArgumentException` for the same kind of mistake. Neither was wrong on its own, but there was no rule, so the two coexisted with no way to predict which a method would use.

The rule applied here: bad caller input raises `\InvalidArgumentException`; an environment that is not as the trait expected raises `\RuntimeException`.

## Changes

| Method | Before | After | Why |
|---|---|---|---|
| `locationsCopyFilesToSut($basedir)` | `RuntimeException` | `InvalidArgumentException` | The caller supplied the path |
| `locationsRealpath($path)` | `RuntimeException` | `InvalidArgumentException` | The caller supplied the path |
| `locationsFixtureDir()` | `RuntimeException` | unchanged | The trait's own expectation about the project layout |
| `logFile($path)` | `InvalidArgumentException` | unchanged | The caller supplied the path |

Two message defects fixed alongside:

- `locationsRealpath()` built its error message from `$path` after `realpath()` had already overwritten it with `FALSE`, so the message always printed an empty path. The resolved value now uses a separate variable and the message reports the path that actually failed.
- `locationsCopyFilesToSut()` said the base directory "does not exist", but the guard is `!is_dir(...)`, which also rejects an existing regular file. It now reads "is not a directory", and the `@throws` description matches.

## Breaking change

Consumers catching `RuntimeException` around `locationsCopyFilesToSut()` or `locationsRealpath()` need to catch `InvalidArgumentException` instead.

## Coverage

The `!is_dir($basedir)` guard had no test, so the changed `throw` line was uncovered. `testLocationsCopyFilesToSutInvalidBasedir` now covers it with two datasets: a path that does not exist, and an existing regular file. The second is the case the old "does not exist" wording described wrongly.

The other changed lines in `locationsRealpath()` are exercised by existing tests; its `throw` sits inside an existing `@codeCoverageIgnore` block.

## Test plan

- [x] `composer test` green: 467 tests
- [x] `composer lint` green: PHPCS, PHPStan level 9, Rector
- [x] Confirmed against the Cobertura report that all three changed executable lines are hit

## Before / After

```
┌─ BEFORE ─────────────────────────────────────────────────────┐
│  logFile(bad path)              InvalidArgumentException     │
│  locationsRealpath(bad path)    RuntimeException             │
│  locationsCopyFilesToSut(...)   RuntimeException             │
│  locationsFixtureDir()          RuntimeException             │
│    no rule; same mistake, two classes                        │
│                                                              │
│  realpath error message printed an empty path                │
│  "does not exist" also raised for an existing file           │
└──────────────────────────────────────────────────────────────┘
                               │
                               ▼
┌─ AFTER ──────────────────────────────────────────────────────┐
│  caller passed a bad value   -> InvalidArgumentException     │
│    logFile, locationsRealpath, locationsCopyFilesToSut       │
│                                                              │
│  environment not as expected -> RuntimeException             │
│    locationsFixtureDir                                       │
│                                                              │
│  messages report the path that failed, and say               │
│  "is not a directory" where that is what was checked         │
└──────────────────────────────────────────────────────────────┘
```
