### PR TITLE
Aligned 'ApplicationTrait' failure messages and completed its assertion parity.

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,10 @@ class MyApplicationTest extends TestCase {
     $this->assertApplicationOutputContainsOrNot(['* Expected', '! Unexpected']);
     $this->assertApplicationErrorOutputContainsOrNot(['* Expected error', '! Unexpected error']);
 
+    // Assert against combined output (standard + error)
+    $this->assertApplicationAnyOutputContains('Expected in either output');
+    $this->assertApplicationAnyOutputNotContains('Should not be in any output');
+
     // Assert that combined output (standard + error) contains or does not contain string(s)
     // Shortcut mode (no prefixes)
     $this->assertApplicationAnyOutputContainsOrNot(['Expected', 'in either output']);

--- a/src/Traits/ApplicationTrait.php
+++ b/src/Traits/ApplicationTrait.php
@@ -19,7 +19,6 @@ use Symfony\Component\Console\Tester\ApplicationTester;
  */
 trait ApplicationTrait {
 
-  use ReflectionTrait;
   use StringTrait;
 
   /**
@@ -276,7 +275,7 @@ trait ApplicationTrait {
       PHP_EOL,
       PHP_EOL,
       $this->applicationTester->getDisplay()
-    ));
+    ) . $this->assertionSuffix());
   }
 
   /**
@@ -292,7 +291,7 @@ trait ApplicationTrait {
       PHP_EOL,
       PHP_EOL,
       $this->applicationTester->getDisplay()
-    ));
+    ) . $this->assertionSuffix());
   }
 
   /**
@@ -317,7 +316,7 @@ trait ApplicationTrait {
           PHP_EOL,
           PHP_EOL,
           $output
-        ));
+        ) . $this->assertionSuffix());
       }
     }
   }
@@ -344,7 +343,7 @@ trait ApplicationTrait {
           PHP_EOL,
           PHP_EOL,
           $output
-        ));
+        ) . $this->assertionSuffix());
       }
     }
   }
@@ -371,7 +370,7 @@ trait ApplicationTrait {
           PHP_EOL,
           PHP_EOL,
           $output
-        ));
+        ) . $this->assertionSuffix());
       }
     }
   }
@@ -398,7 +397,7 @@ trait ApplicationTrait {
           PHP_EOL,
           PHP_EOL,
           $output
-        ));
+        ) . $this->assertionSuffix());
       }
     }
   }
@@ -439,10 +438,10 @@ trait ApplicationTrait {
     $this->assertStringContainsOrNot(
       $output,
       $expected,
-      $message ?: "Application output exact match failed for '%s'",
-      $message ?: "Application output does not contain '%s'",
-      $message ?: "Application output should not exactly match '%s'",
-      $message ?: "Application output contains '%s' but should not"
+      $message ?: "Application output exact match failed for '%s'" . $this->assertionSuffix(),
+      $message ?: "Application output does not contain '%s'" . $this->assertionSuffix(),
+      $message ?: "Application output should not exactly match '%s'" . $this->assertionSuffix(),
+      $message ?: "Application output contains '%s' but should not" . $this->assertionSuffix()
     );
   }
 
@@ -482,11 +481,67 @@ trait ApplicationTrait {
     $this->assertStringContainsOrNot(
       $output,
       $expected,
-      $message ?: "Application error output exact match failed for '%s'",
-      $message ?: "Application error output does not contain '%s'",
-      $message ?: "Application error output should not exactly match '%s'",
-      $message ?: "Application error output contains '%s' but should not"
+      $message ?: "Application error output exact match failed for '%s'" . $this->assertionSuffix(),
+      $message ?: "Application error output does not contain '%s'" . $this->assertionSuffix(),
+      $message ?: "Application error output should not exactly match '%s'" . $this->assertionSuffix(),
+      $message ?: "Application error output contains '%s' but should not" . $this->assertionSuffix()
     );
+  }
+
+  /**
+   * Asserts that either application output contains expected string(s).
+   *
+   * Checks the standard output and error output combined into a single string.
+   *
+   * @param array|string $expected
+   *   Expected string or strings to check for in either output.
+   * @param ?string $message
+   *   Optional failure message.
+   */
+  public function assertApplicationAnyOutputContains(array|string $expected, ?string $message = NULL): void {
+    $this->assertNotNull($this->applicationTester, $message ?: 'Application is not initialized');
+    $output = $this->applicationTester->getDisplay() . $this->applicationTester->getErrorOutput();
+
+    $expected = is_array($expected) ? $expected : [$expected];
+
+    foreach ($expected as $value) {
+      if (is_string($value)) {
+        $this->assertStringContainsString($value, $output, $message ?: sprintf(
+          "Application standard or error output does not contain '%s'.%sOutput:%s%s",
+          $value,
+          PHP_EOL,
+          PHP_EOL,
+          $output
+        ) . $this->assertionSuffix());
+      }
+    }
+  }
+
+  /**
+   * Asserts that neither application output contains expected string(s).
+   *
+   * @param array|string $expected
+   *   String or strings that should not be in either output.
+   * @param ?string $message
+   *   Optional failure message.
+   */
+  public function assertApplicationAnyOutputNotContains(array|string $expected, ?string $message = NULL): void {
+    $this->assertNotNull($this->applicationTester, $message ?: 'Application is not initialized');
+    $output = $this->applicationTester->getDisplay() . $this->applicationTester->getErrorOutput();
+
+    $expected = is_array($expected) ? $expected : [$expected];
+
+    foreach ($expected as $value) {
+      if (is_string($value)) {
+        $this->assertStringNotContainsString($value, $output, $message ?: sprintf(
+          "Application standard or error output contains '%s' but should not.%sOutput:%s%s",
+          $value,
+          PHP_EOL,
+          PHP_EOL,
+          $output
+        ) . $this->assertionSuffix());
+      }
+    }
   }
 
   /**
@@ -527,10 +582,10 @@ trait ApplicationTrait {
     $this->assertStringContainsOrNot(
       $output,
       $expected,
-      $message ?: "Application output exact match failed for '%s'",
-      $message ?: "Application output does not contain '%s'",
-      $message ?: "Application output should not exactly match '%s'",
-      $message ?: "Application output contains '%s' but should not"
+      $message ?: "Application output exact match failed for '%s'" . $this->assertionSuffix(),
+      $message ?: "Application output does not contain '%s'" . $this->assertionSuffix(),
+      $message ?: "Application output should not exactly match '%s'" . $this->assertionSuffix(),
+      $message ?: "Application output contains '%s' but should not" . $this->assertionSuffix()
     );
   }
 

--- a/tests/Unit/ApplicationTraitTest.php
+++ b/tests/Unit/ApplicationTraitTest.php
@@ -675,6 +675,44 @@ final class ApplicationTraitTest extends UnitTestCase {
     ]);
   }
 
+  public function testApplicationAnyOutputContains(): void {
+    $this->applicationInitFromCommand(ErrorOutputCommand::class);
+    $this->applicationRun([]);
+
+    $this->assertApplicationSuccessful();
+
+    $this->assertApplicationAnyOutputContains('Test Error');
+    $this->assertApplicationAnyOutputContains(['Test Error', 'Output message']);
+  }
+
+  public function testApplicationAnyOutputContainsFailure(): void {
+    $this->applicationInitFromCommand(ErrorOutputCommand::class);
+    $this->applicationRun([]);
+
+    $this->expectException(ExpectationFailedException::class);
+
+    $this->assertApplicationAnyOutputContains('Nonexistent string');
+  }
+
+  public function testApplicationAnyOutputNotContains(): void {
+    $this->applicationInitFromCommand(ErrorOutputCommand::class);
+    $this->applicationRun([]);
+
+    $this->assertApplicationSuccessful();
+
+    $this->assertApplicationAnyOutputNotContains('Nonexistent string');
+    $this->assertApplicationAnyOutputNotContains(['NotFound1', 'NotFound2']);
+  }
+
+  public function testApplicationAnyOutputNotContainsFailure(): void {
+    $this->applicationInitFromCommand(ErrorOutputCommand::class);
+    $this->applicationRun([]);
+
+    $this->expectException(ExpectationFailedException::class);
+
+    $this->assertApplicationAnyOutputNotContains('Test Error');
+  }
+
   public function testApplicationAnyOutputContainsOrNotShortcutMode(): void {
     $this->applicationInitFromCommand(ErrorOutputCommand::class);
     $this->applicationRun([]);


### PR DESCRIPTION
> Stacked on #104. Review that one first; this PR's diff is only its own change.

## Summary

`ProcessTrait` and `ApplicationTrait` are sibling traits with method-for-method parallel assertion families, but they had drifted apart in two ways: `ProcessTrait` appended `assertionSuffix()` to every generated failure message and `ApplicationTrait` appended it to none, and `ApplicationTrait` was missing two of the three combined-output assertions.

## Changes

- `ApplicationTrait` appends `assertionSuffix()` to its generated failure messages, matching `ProcessTrait`. This covers the 6 `sprintf` sites and the 12 `ContainsOrNot` message templates.
- Adds `assertApplicationAnyOutputContains()` and `assertApplicationAnyOutputNotContains()`, completing the trio `ProcessTrait` already had.
- Removes `use ReflectionTrait;` from `ApplicationTrait`, which called none of its members.

## Breaking changes

**Failure message text changes.** Assertions that fail through `ApplicationTrait` now carry the assertion suffix. Tests asserting on exact failure text may need updating; `expectExceptionMessage()` matches substrings and is unaffected.

**`ApplicationTrait` no longer provides `ReflectionTrait`'s methods.** Consumers who relied on inheriting `callProtectedMethod()`, `setProtectedValue()` or `getProtectedValue()` transitively through `ApplicationTrait` must now compose `ReflectionTrait` directly or extend `UnitTestCase`.

Note this is one of the changes no test in this repository can catch. It only affects code outside it.

## Test plan

- [x] `composer test` green: 469 tests
- [x] `composer lint` green: PHPCS, PHPStan level 9, Rector
- [x] Four new tests cover both new assertions, passing and failing

## Before / After

```
┌─ BEFORE ─────────────────────────────────────────────────────┐
│  assertion suffix                                            │
│    ProcessTrait      20 of 20 sites                          │
│    ApplicationTrait   0 of 18 sites                          │
│                                                              │
│  combined-output assertions                                  │
│    ProcessTrait      Contains, NotContains, ContainsOrNot    │
│    ApplicationTrait                        ContainsOrNot     │
│                                                              │
│  ApplicationTrait composes ReflectionTrait, calls none of it │
└──────────────────────────────────────────────────────────────┘
                               │
                               ▼
┌─ AFTER ──────────────────────────────────────────────────────┐
│  assertion suffix                                            │
│    ProcessTrait      20 of 20 sites                          │
│    ApplicationTrait  18 of 18 sites                          │
│                                                              │
│  combined-output assertions                                  │
│    ProcessTrait      Contains, NotContains, ContainsOrNot    │
│    ApplicationTrait  Contains, NotContains, ContainsOrNot    │
│                                                              │
│  ApplicationTrait composes only what it uses                 │
└──────────────────────────────────────────────────────────────┘
```
