### PR TITLE
Prefixed all trait members with their trait prefix and documented the rule.

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,6 +95,21 @@ composer install
 - Local variables/method arguments: `snake_case`
 - Method names/class properties: `camelCase`
 
+### Trait Member Prefixes
+
+Every method and property declared in a trait under `src/Traits/` starts with that trait's prefix, so members remain traceable to their trait once composed into a consuming class.
+
+The prefix is the trait name minus the `Trait` suffix, lower-camel-cased: `ApplicationTrait` uses `application*`, `EnvTrait` uses `env*`, `TuiTrait` uses `tui*`, `LocationsTrait` uses `locations*`, `ProcessTrait` uses `process*`.
+
+Four deliberate exceptions, each of which stays as it is:
+
+- **Assertion methods keep the PHPUnit `assert` prefix first**, with the trait's subject immediately after: `assertProcessSuccessful()`, `assertApplicationOutputContains()`, `assertArrayContainsString()`, `assertStringContainsOrNot()`. This keeps them grouped with PHPUnit's own assertions in editor autocomplete.
+- **`LoggerTrait` uses `log` rather than `logger`**, applied consistently to every method and property: `logSetVerbose()`, `logStepStart()`, `logFormatElapsedTime()`, `$logSteps`, `$logIsVerbose`.
+- **`SerializableClosureTrait` keeps `cw()` and `cu()`.** The names are deliberately short because they appear inline in data providers, where longer names push lines past the limit. The trait docblock records this.
+- **`ReflectionTrait` keeps `callProtectedMethod()`, `setProtectedValue()` and `getProtectedValue()`.** The names read naturally at the call site and are in wide use.
+
+`LocationsTrait`'s `$root`, `$fixtures`, `$workspace`, `$repo`, `$sut` and `$tmp` properties are unprefixed. They are read directly as `self::$fixtures` and `self::$tmp` throughout consuming test suites, so they are left alone; the accessors `locationsRoot()`, `locationsFixtures()` and the rest already follow the rule.
+
 ## Testing Patterns
 
 ### PHPUnit Structure

--- a/README.md
+++ b/README.md
@@ -296,7 +296,7 @@ class MyProcessTest extends TestCase {
   protected function setUp(): void {
     // Configure process behavior.
     $this->processCwd = NULL; // Current working directory (NULL for current PHP process dir).
-    $this->processStreamOutput = FALSE; // Whether to stream an output during process execution.
+    $this->processStreamingOutput = FALSE; // Whether to stream an output during process execution.
   }
 
   protected function tearDown(): void {
@@ -591,7 +591,7 @@ class MyLoggerTest extends TestCase {
 
   protected function setUp(): void {
     // Enable verbose logging for debugging
-    static::loggerSetVerbose(TRUE);
+    static::logSetVerbose(TRUE);
   }
 
   public function testHierarchicalWorkflow() {
@@ -631,8 +631,8 @@ class MyLoggerTest extends TestCase {
 - `logSubstep(string)` - Indented substep messages
 - `logNote(string)` - Indented note messages
 - `logStepSummary(?string, string)` - Hierarchical step summary table with configurable indentation
-- `loggerSetVerbose(bool)` - Control verbose mode
-- `loggerSetOutputStream(resource|null)` - Set custom output stream (defaults to STDERR)
+- `logSetVerbose(bool)` - Control verbose mode
+- `logSetOutputStream(resource|null)` - Set custom output stream (defaults to STDERR)
 
 **Key features:**
 - Hierarchical step tracking with parent-child relationships

--- a/src/Traits/LoggerTrait.php
+++ b/src/Traits/LoggerTrait.php
@@ -14,14 +14,14 @@ trait LoggerTrait {
   /**
    * Controls whether logging output is enabled.
    */
-  protected static bool $loggerIsVerbose = FALSE;
+  protected static bool $logIsVerbose = FALSE;
 
   /**
    * The output stream for logging. Defaults to STDERR if not set.
    *
    * @var resource|null
    */
-  protected static $loggerOutputStream;
+  protected static $logOutputStream;
 
   /**
    * Stores all step tracking information.
@@ -33,19 +33,19 @@ trait LoggerTrait {
    * - 'elapsed': The elapsed time in seconds (null if not finished)
    * - 'parent_stack': Array of parent step names for hierarchy.
    */
-  protected static array $loggerSteps = [];
+  protected static array $logSteps = [];
 
   /**
    * Stack of currently running steps for hierarchy tracking.
    *
    * @var array<string>
    */
-  protected static array $loggerStepStack = [];
+  protected static array $logStepStack = [];
 
   /**
    * Prefix for identifying step methods.
    */
-  protected static string $loggerStepMethodPrefix = 'step';
+  protected static string $logStepMethodPrefix = 'step';
 
   /**
    * Sets the verbose mode for logging.
@@ -53,8 +53,8 @@ trait LoggerTrait {
    * @param bool $verbose
    *   TRUE to enable verbose logging, FALSE to disable.
    */
-  public static function loggerSetVerbose(bool $verbose): void {
-    static::$loggerIsVerbose = $verbose;
+  public static function logSetVerbose(bool $verbose): void {
+    static::$logIsVerbose = $verbose;
   }
 
   /**
@@ -66,12 +66,12 @@ trait LoggerTrait {
    * @throws \InvalidArgumentException
    *   When the provided stream is not a valid resource or NULL.
    */
-  public static function loggerSetOutputStream($stream): void {
+  public static function logSetOutputStream($stream): void {
     if (!is_resource($stream) && $stream !== NULL) {
       throw new \InvalidArgumentException('Stream must be a valid resource or NULL.');
     }
 
-    static::$loggerOutputStream = $stream;
+    static::$logOutputStream = $stream;
   }
 
   /**
@@ -80,8 +80,8 @@ trait LoggerTrait {
    * @return resource
    *   The output stream resource (STDERR if not set).
    */
-  protected static function getOutputStream() {
-    return static::$loggerOutputStream ?: STDERR;
+  protected static function logGetOutputStream() {
+    return static::$logOutputStream ?: STDERR;
   }
 
   /**
@@ -91,10 +91,10 @@ trait LoggerTrait {
    *   The message to log.
    */
   public static function log(string $message): void {
-    if (!static::$loggerIsVerbose) {
+    if (!static::$logIsVerbose) {
       return;
     }
-    fwrite(static::getOutputStream(), PHP_EOL . $message . PHP_EOL);
+    fwrite(static::logGetOutputStream(), PHP_EOL . $message . PHP_EOL);
   }
 
   /**
@@ -116,7 +116,7 @@ trait LoggerTrait {
     if ($min_width <= 0) {
       throw new \InvalidArgumentException('Minimum width must be a positive integer.');
     }
-    if (!static::$loggerIsVerbose) {
+    if (!static::$logIsVerbose) {
       return;
     }
     $delimiter_char = $double_border ? '=' : '-';
@@ -136,7 +136,7 @@ trait LoggerTrait {
 
     $bottom_line = str_repeat($delimiter_char, strlen($top_line));
 
-    fwrite(static::getOutputStream(), PHP_EOL . $top_line . PHP_EOL);
+    fwrite(static::logGetOutputStream(), PHP_EOL . $top_line . PHP_EOL);
 
     if (!empty($message)) {
       $message = trim($message);
@@ -156,10 +156,10 @@ trait LoggerTrait {
       }
 
       foreach ($wrapped_lines as $line) {
-        fwrite(static::getOutputStream(), $line . PHP_EOL);
+        fwrite(static::logGetOutputStream(), $line . PHP_EOL);
       }
 
-      fwrite(static::getOutputStream(), $bottom_line . PHP_EOL);
+      fwrite(static::logGetOutputStream(), $bottom_line . PHP_EOL);
     }
   }
 
@@ -177,7 +177,7 @@ trait LoggerTrait {
    *   When the file cannot be read.
    */
   public static function logFile(string $path, ?string $message = NULL): void {
-    if (!static::$loggerIsVerbose) {
+    if (!static::$logIsVerbose) {
       return;
     }
     if (!file_exists($path)) {
@@ -206,9 +206,9 @@ trait LoggerTrait {
     $trace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 2);
     $step = $trace[1]['function'] ?? 'unknown';
 
-    $parent_stack = static::$loggerStepStack;
+    $parent_stack = static::$logStepStack;
 
-    static::$loggerSteps[] = [
+    static::$logSteps[] = [
       'name' => $step,
       'start_time' => microtime(TRUE),
       'end_time' => NULL,
@@ -216,13 +216,13 @@ trait LoggerTrait {
       'parent_stack' => $parent_stack,
     ];
 
-    static::$loggerStepStack[] = $step;
+    static::$logStepStack[] = $step;
 
-    $prefix = str_starts_with($step, static::$loggerStepMethodPrefix) ? sprintf('%s START', strtoupper(static::$loggerStepMethodPrefix)) : 'STEP START';
+    $prefix = str_starts_with($step, static::$logStepMethodPrefix) ? sprintf('%s START', strtoupper(static::$logStepMethodPrefix)) : 'STEP START';
     static::logSection($prefix . ' | ' . $step, $message, FALSE, 40);
 
-    if (static::$loggerIsVerbose) {
-      fwrite(static::getOutputStream(), PHP_EOL);
+    if (static::$logIsVerbose) {
+      fwrite(static::logGetOutputStream(), PHP_EOL);
     }
   }
 
@@ -236,12 +236,12 @@ trait LoggerTrait {
     $trace = debug_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS, 2);
     $step = $trace[1]['function'] ?? 'unknown';
 
-    $prefix = str_starts_with($step, static::$loggerStepMethodPrefix) ? sprintf('%s DONE', strtoupper(static::$loggerStepMethodPrefix)) : 'STEP DONE';
+    $prefix = str_starts_with($step, static::$logStepMethodPrefix) ? sprintf('%s DONE', strtoupper(static::$logStepMethodPrefix)) : 'STEP DONE';
     $section_title = $prefix . ' | ' . $step;
     $step_index = NULL;
 
-    for ($i = count(static::$loggerSteps) - 1; $i >= 0; $i--) {
-      if (static::$loggerSteps[$i]['name'] === $step && static::$loggerSteps[$i]['end_time'] === NULL) {
+    for ($i = count(static::$logSteps) - 1; $i >= 0; $i--) {
+      if (static::$logSteps[$i]['name'] === $step && static::$logSteps[$i]['end_time'] === NULL) {
         $step_index = $i;
         break;
       }
@@ -249,23 +249,23 @@ trait LoggerTrait {
 
     if ($step_index !== NULL) {
       $end_time = microtime(TRUE);
-      $elapsed_time = $end_time - static::$loggerSteps[$step_index]['start_time'];
-      $formatted_time = static::formatElapsedTime($elapsed_time);
+      $elapsed_time = $end_time - static::$logSteps[$step_index]['start_time'];
+      $formatted_time = static::logFormatElapsedTime($elapsed_time);
 
-      static::$loggerSteps[$step_index]['end_time'] = $end_time;
-      static::$loggerSteps[$step_index]['elapsed'] = $elapsed_time;
+      static::$logSteps[$step_index]['end_time'] = $end_time;
+      static::$logSteps[$step_index]['elapsed'] = $elapsed_time;
 
       $section_title .= ' | ' . $formatted_time;
 
-      $stack_key = array_search($step, static::$loggerStepStack, TRUE);
+      $stack_key = array_search($step, static::$logStepStack, TRUE);
       if ($stack_key !== FALSE) {
-        array_splice(static::$loggerStepStack, (int) $stack_key, 1);
+        array_splice(static::$logStepStack, (int) $stack_key, 1);
       }
     }
 
     static::logSection($section_title, $message, FALSE, 40);
-    if (static::$loggerIsVerbose) {
-      fwrite(static::getOutputStream(), PHP_EOL);
+    if (static::$logIsVerbose) {
+      fwrite(static::logGetOutputStream(), PHP_EOL);
     }
   }
 
@@ -276,10 +276,10 @@ trait LoggerTrait {
    *   The substep message to log.
    */
   public static function logSubstep(string $message): void {
-    if (!static::$loggerIsVerbose) {
+    if (!static::$logIsVerbose) {
       return;
     }
-    fwrite(static::getOutputStream(), '  --> ' . $message . PHP_EOL);
+    fwrite(static::logGetOutputStream(), '  --> ' . $message . PHP_EOL);
   }
 
   /**
@@ -289,10 +289,10 @@ trait LoggerTrait {
    *   The note message to log.
    */
   public static function logNote(string $message): void {
-    if (!static::$loggerIsVerbose) {
+    if (!static::$logIsVerbose) {
       return;
     }
-    fwrite(static::getOutputStream(), '    > ' . $message . PHP_EOL);
+    fwrite(static::logGetOutputStream(), '    > ' . $message . PHP_EOL);
   }
 
   /**
@@ -305,7 +305,7 @@ trait LoggerTrait {
    *   The formatted summary table.
    */
   public static function logStepSummary(string $indent = '  '): string {
-    if (empty(static::$loggerSteps)) {
+    if (empty(static::$logSteps)) {
       return '';
     }
 
@@ -315,7 +315,7 @@ trait LoggerTrait {
       $depth = count($step['parent_stack']);
       $indentation = str_repeat($indent, $depth);
       return strlen($indentation . $step['name']);
-    }, static::$loggerSteps);
+    }, static::$logSteps);
     $max_name_length = max($name_lengths);
     // Minimum for "Step" header.
     $max_name_length = max($max_name_length, 4);
@@ -340,9 +340,9 @@ trait LoggerTrait {
     $lines[] = $header;
     $lines[] = $separator;
 
-    foreach (static::$loggerSteps as $step) {
+    foreach (static::$logSteps as $step) {
       $status = $step['end_time'] === NULL ? 'Running' : 'Complete';
-      $elapsed = $step['elapsed'] === NULL ? '-' : static::formatElapsedTime($step['elapsed']);
+      $elapsed = $step['elapsed'] === NULL ? '-' : static::logFormatElapsedTime($step['elapsed']);
 
       $depth = count($step['parent_stack']);
       $indentation = str_repeat($indent, $depth);
@@ -373,7 +373,7 @@ trait LoggerTrait {
    * @return string
    *   The formatted time string (e.g., "1m 23s" or "45s").
    */
-  protected static function formatElapsedTime(float $elapsed_seconds): string {
+  protected static function logFormatElapsedTime(float $elapsed_seconds): string {
     $total_seconds = (int) round($elapsed_seconds);
 
     if ($total_seconds < 60) {
@@ -396,7 +396,7 @@ trait LoggerTrait {
    * @return string
    *   The locations' info.
    */
-  public function loggerInfo(): string {
+  public function logInfo(): string {
     $lines = '';
     $lines .= 'STEP SUMMARY' . PHP_EOL;
     return $lines . static::logStepSummary();

--- a/src/Traits/ProcessTrait.php
+++ b/src/Traits/ProcessTrait.php
@@ -33,7 +33,7 @@ trait ProcessTrait {
   /**
    * Stream output of the process while it is running.
    */
-  protected bool $processStreamOutput = FALSE;
+  protected bool $processStreamingOutput = FALSE;
 
   /**
    * Characters to prefix streaming standard output.
@@ -195,7 +195,7 @@ trait ProcessTrait {
     $this->process->setIdleTimeout($idle_timeout);
 
     try {
-      $this->process->run($this->processStreamOutput ? $this->processStreamingOutputCallback() : NULL);
+      $this->process->run($this->processStreamingOutput ? $this->processStreamingOutputCallback() : NULL);
     }
     // @codeCoverageIgnoreStart
     catch (ProcessTimedOutException $process_timed_out_exception) {
@@ -328,7 +328,7 @@ trait ProcessTrait {
         $line = $prefix . $line . $eol;
 
         if (static::$processStreamingOutputShouldDim) {
-          $line = static::dim($line);
+          $line = static::processColorDim($line);
         }
 
         // Start the output on a new line for STDOUT.
@@ -352,7 +352,7 @@ trait ProcessTrait {
    * @return string
    *   The dimmed text.
    */
-  protected static function dim(string $text, string $eol = "\n"): string {
+  protected static function processColorDim(string $text, string $eol = "\n"): string {
     // Ensure $eol is non-empty for explode().
     $eol = $eol ?: "\n";
     $lines = explode($eol, $text);

--- a/tests/Functional/LoggerTraitFunctionalTest.php
+++ b/tests/Functional/LoggerTraitFunctionalTest.php
@@ -22,13 +22,13 @@ final class LoggerTraitFunctionalTest extends UnitTestCase {
    */
   protected function setUp(): void {
     parent::setUp();
-    self::loggerSetVerbose(FALSE);
+    self::logSetVerbose(FALSE);
 
     $reflection_class = new \ReflectionClass(self::class);
-    $steps_property = $reflection_class->getProperty('loggerSteps');
+    $steps_property = $reflection_class->getProperty('logSteps');
     $steps_property->setValue(NULL, []);
 
-    $stack_property = $reflection_class->getProperty('loggerStepStack');
+    $stack_property = $reflection_class->getProperty('logStepStack');
     $stack_property->setValue(NULL, []);
   }
 
@@ -36,7 +36,7 @@ final class LoggerTraitFunctionalTest extends UnitTestCase {
    * {@inheritdoc}
    */
   protected function tearDown(): void {
-    self::loggerSetOutputStream(NULL);
+    self::logSetOutputStream(NULL);
     parent::tearDown();
   }
 
@@ -47,8 +47,8 @@ final class LoggerTraitFunctionalTest extends UnitTestCase {
    */
   #[DoesNotPerformAssertions]
   public function testFunctionalBasicLogging(): void {
-    self::loggerSetOutputStream(NULL);
-    self::loggerSetVerbose(TRUE);
+    self::logSetOutputStream(NULL);
+    self::logSetVerbose(TRUE);
 
     self::log('This is a basic log message');
     self::logSection('TEST SECTION', 'This is a test section with content');
@@ -61,8 +61,8 @@ final class LoggerTraitFunctionalTest extends UnitTestCase {
    */
   #[DoesNotPerformAssertions]
   public function testFunctionalStepWorkflow(): void {
-    self::loggerSetOutputStream(NULL);
-    self::loggerSetVerbose(TRUE);
+    self::logSetOutputStream(NULL);
+    self::logSetVerbose(TRUE);
 
     self::logStepStart('Processing data');
     self::logSubstep('Loading configuration');
@@ -87,8 +87,8 @@ final class LoggerTraitFunctionalTest extends UnitTestCase {
    */
   #[DoesNotPerformAssertions]
   public function testFunctionalSectionFormatting(): void {
-    self::loggerSetOutputStream(NULL);
-    self::loggerSetVerbose(TRUE);
+    self::logSetOutputStream(NULL);
+    self::logSetVerbose(TRUE);
 
     self::logSection('STANDARD SECTION', 'This is a standard section with single border');
     self::logSection('DOUBLE BORDER SECTION', 'This section uses double border characters', TRUE);
@@ -103,8 +103,8 @@ final class LoggerTraitFunctionalTest extends UnitTestCase {
    */
   #[DoesNotPerformAssertions]
   public function testFunctionalFileLogging(): void {
-    self::loggerSetOutputStream(NULL);
-    self::loggerSetVerbose(TRUE);
+    self::logSetOutputStream(NULL);
+    self::logSetVerbose(TRUE);
 
     $temp_file = tempnam(sys_get_temp_dir(), 'logger_functional_test');
     file_put_contents($temp_file, "Sample file content\nLine 2\nLine 3\n");
@@ -121,8 +121,8 @@ final class LoggerTraitFunctionalTest extends UnitTestCase {
    */
   #[DoesNotPerformAssertions]
   public function testFunctionalHierarchicalSteps(): void {
-    self::loggerSetOutputStream(NULL);
-    self::loggerSetVerbose(TRUE);
+    self::logSetOutputStream(NULL);
+    self::logSetVerbose(TRUE);
 
     $this->stepDeploymentProcess();
 

--- a/tests/Functional/ProcessTraitArgumentsTest.php
+++ b/tests/Functional/ProcessTraitArgumentsTest.php
@@ -19,7 +19,7 @@ final class ProcessTraitArgumentsTest extends UnitTestCase {
 
   protected function setUp(): void {
     parent::setUp();
-    $this->processStreamOutput = FALSE;
+    $this->processStreamingOutput = FALSE;
   }
 
   protected function tearDown(): void {

--- a/tests/Functional/ProcessTraitScenariosTest.php
+++ b/tests/Functional/ProcessTraitScenariosTest.php
@@ -24,7 +24,7 @@ final class ProcessTraitScenariosTest extends UnitTestCase {
 
   protected function setUp(): void {
     parent::setUp();
-    $this->processStreamOutput = self::isDebug();
+    $this->processStreamingOutput = self::isDebug();
   }
 
   protected function tearDown(): void {

--- a/tests/Unit/LoggerTraitTest.php
+++ b/tests/Unit/LoggerTraitTest.php
@@ -30,20 +30,20 @@ final class LoggerTraitTest extends UnitTestCase {
    */
   protected function setUp(): void {
     parent::setUp();
-    self::loggerSetVerbose(FALSE);
+    self::logSetVerbose(FALSE);
 
     $buffer = fopen('php://memory', 'r+');
     if ($buffer === FALSE) {
       throw new \RuntimeException('Failed to create memory buffer');
     }
     $this->logBuffer = $buffer;
-    self::loggerSetOutputStream($this->logBuffer);
+    self::logSetOutputStream($this->logBuffer);
 
     $reflection_class = new \ReflectionClass(self::class);
-    $steps_property = $reflection_class->getProperty('loggerSteps');
+    $steps_property = $reflection_class->getProperty('logSteps');
     $steps_property->setValue(NULL, []);
 
-    $stack_property = $reflection_class->getProperty('loggerStepStack');
+    $stack_property = $reflection_class->getProperty('logStepStack');
     $stack_property->setValue(NULL, []);
   }
 
@@ -55,7 +55,7 @@ final class LoggerTraitTest extends UnitTestCase {
       fclose($this->logBuffer);
     }
 
-    self::loggerSetOutputStream(NULL);
+    self::logSetOutputStream(NULL);
 
     parent::tearDown();
   }
@@ -75,7 +75,7 @@ final class LoggerTraitTest extends UnitTestCase {
    * Test verbose mode setter and getter.
    */
   public function testVerboseMode(): void {
-    self::loggerSetVerbose(TRUE);
+    self::logSetVerbose(TRUE);
     self::log('Verbose message');
     self::logSection('Verbose Section', 'Verbose content');
 
@@ -89,9 +89,9 @@ final class LoggerTraitTest extends UnitTestCase {
       throw new \RuntimeException('Failed to create memory buffer');
     }
     $this->logBuffer = $buffer;
-    self::loggerSetOutputStream($this->logBuffer);
+    self::logSetOutputStream($this->logBuffer);
 
-    self::loggerSetVerbose(FALSE);
+    self::logSetVerbose(FALSE);
     self::log('Silent message');
     self::logSection('Silent Section', 'Silent content');
 
@@ -103,7 +103,7 @@ final class LoggerTraitTest extends UnitTestCase {
    * Test log method with verbose mode disabled.
    */
   public function testLogSilentMode(): void {
-    self::loggerSetVerbose(FALSE);
+    self::logSetVerbose(FALSE);
 
     self::log('Test message');
 
@@ -115,7 +115,7 @@ final class LoggerTraitTest extends UnitTestCase {
    * Test log method with verbose mode enabled.
    */
   public function testLogVerboseMode(): void {
-    self::loggerSetVerbose(TRUE);
+    self::logSetVerbose(TRUE);
 
     self::log('Test message');
 
@@ -127,7 +127,7 @@ final class LoggerTraitTest extends UnitTestCase {
    * Test logSection method - with visual output for inspection.
    */
   public function testLogSection(): void {
-    self::loggerSetVerbose(TRUE);
+    self::logSetVerbose(TRUE);
 
     self::logSection('TEST TITLE');
 
@@ -153,7 +153,7 @@ final class LoggerTraitTest extends UnitTestCase {
    * Test logSection method with invalid min_width parameter.
    */
   public function testLogSectionWithInvalidMinWidth(): void {
-    self::loggerSetVerbose(TRUE);
+    self::logSetVerbose(TRUE);
 
     $this->expectException(\InvalidArgumentException::class);
     $this->expectExceptionMessage('Minimum width must be a positive integer.');
@@ -165,7 +165,7 @@ final class LoggerTraitTest extends UnitTestCase {
    * Test logSection method with negative min_width parameter.
    */
   public function testLogSectionWithNegativeMinWidth(): void {
-    self::loggerSetVerbose(TRUE);
+    self::logSetVerbose(TRUE);
 
     $this->expectException(\InvalidArgumentException::class);
     $this->expectExceptionMessage('Minimum width must be a positive integer.');
@@ -178,7 +178,7 @@ final class LoggerTraitTest extends UnitTestCase {
    */
   #[DoesNotPerformAssertions]
   public function testLogFileWithExistingFile(): void {
-    self::loggerSetVerbose(TRUE);
+    self::logSetVerbose(TRUE);
 
     $temp_file = tempnam(sys_get_temp_dir(), 'logger_test');
     file_put_contents($temp_file, 'Test file content');
@@ -193,7 +193,7 @@ final class LoggerTraitTest extends UnitTestCase {
    * Test logFile method with unreadable file.
    */
   public function testLogFileWithUnreadableFile(): void {
-    self::loggerSetVerbose(TRUE);
+    self::logSetVerbose(TRUE);
 
     $temp_file = tempnam(sys_get_temp_dir(), 'logger_test');
     file_put_contents($temp_file, 'Test content');
@@ -216,7 +216,7 @@ final class LoggerTraitTest extends UnitTestCase {
    * Test logFile method with non-existent file.
    */
   public function testLogFileWithNonExistentFile(): void {
-    self::loggerSetVerbose(TRUE);
+    self::logSetVerbose(TRUE);
 
     $this->expectException(\InvalidArgumentException::class);
     $this->expectExceptionMessage('File /non/existent/file does not exist.');
@@ -229,7 +229,7 @@ final class LoggerTraitTest extends UnitTestCase {
    */
   #[DoesNotPerformAssertions]
   public function testLogFileWithVerboseDisabled(): void {
-    self::loggerSetVerbose(FALSE);
+    self::logSetVerbose(FALSE);
 
     $temp_file = tempnam(sys_get_temp_dir(), 'logger_test');
     file_put_contents($temp_file, 'Test content');
@@ -244,7 +244,7 @@ final class LoggerTraitTest extends UnitTestCase {
    */
   #[DoesNotPerformAssertions]
   public function testLogSectionWithVerboseDisabled(): void {
-    self::loggerSetVerbose(FALSE);
+    self::logSetVerbose(FALSE);
 
     self::logSection('TEST TITLE', 'Test message');
   }
@@ -254,7 +254,7 @@ final class LoggerTraitTest extends UnitTestCase {
    */
   #[DoesNotPerformAssertions]
   public function testSilentModeForAllMethods(): void {
-    self::loggerSetVerbose(FALSE);
+    self::logSetVerbose(FALSE);
 
     self::log('Test message');
     self::logSection('TEST TITLE', 'Test message');
@@ -270,11 +270,11 @@ final class LoggerTraitTest extends UnitTestCase {
    */
   #[DoesNotPerformAssertions]
   public function testVerboseModePersistence(): void {
-    self::loggerSetVerbose(TRUE);
+    self::logSetVerbose(TRUE);
 
     self::log('Message 1');
 
-    self::loggerSetVerbose(FALSE);
+    self::logSetVerbose(FALSE);
 
     self::log('Message 2');
   }
@@ -283,7 +283,7 @@ final class LoggerTraitTest extends UnitTestCase {
    * Test logStepStart method with verbose mode enabled.
    */
   public function testLogStepStartVerboseMode(): void {
-    self::loggerSetVerbose(TRUE);
+    self::logSetVerbose(TRUE);
 
     self::logStepStart();
 
@@ -296,10 +296,10 @@ final class LoggerTraitTest extends UnitTestCase {
    * Test logStepStart method with custom step method prefix.
    */
   public function testLogStepStartWithCustomPrefix(): void {
-    self::loggerSetVerbose(TRUE);
+    self::logSetVerbose(TRUE);
 
-    $original_prefix = self::$loggerStepMethodPrefix;
-    self::$loggerStepMethodPrefix = 'process';
+    $original_prefix = self::$logStepMethodPrefix;
+    self::$logStepMethodPrefix = 'process';
 
     try {
       $this->processTest();
@@ -308,7 +308,7 @@ final class LoggerTraitTest extends UnitTestCase {
       $this->assertStringContainsString('PROCESS START | processTest', $output);
     }
     finally {
-      self::$loggerStepMethodPrefix = $original_prefix;
+      self::$logStepMethodPrefix = $original_prefix;
     }
   }
 
@@ -317,7 +317,7 @@ final class LoggerTraitTest extends UnitTestCase {
    */
   #[DoesNotPerformAssertions]
   public function testLogStepStartSilentMode(): void {
-    self::loggerSetVerbose(FALSE);
+    self::logSetVerbose(FALSE);
 
     self::logStepStart();
     self::logStepStart('Silent step start');
@@ -327,7 +327,7 @@ final class LoggerTraitTest extends UnitTestCase {
    * Test logStepFinish method with verbose mode enabled.
    */
   public function testLogStepFinishVerboseMode(): void {
-    self::loggerSetVerbose(TRUE);
+    self::logSetVerbose(TRUE);
 
     self::logStepStart();
     self::logStepFinish('Completed the test step');
@@ -342,10 +342,10 @@ final class LoggerTraitTest extends UnitTestCase {
    * Test logStepFinish method with custom step method prefix.
    */
   public function testLogStepFinishWithCustomPrefix(): void {
-    self::loggerSetVerbose(TRUE);
+    self::logSetVerbose(TRUE);
 
-    $original_prefix = self::$loggerStepMethodPrefix;
-    self::$loggerStepMethodPrefix = 'process';
+    $original_prefix = self::$logStepMethodPrefix;
+    self::$logStepMethodPrefix = 'process';
 
     try {
       $this->processFinishTest();
@@ -355,7 +355,7 @@ final class LoggerTraitTest extends UnitTestCase {
       $this->assertStringContainsString('PROCESS DONE | processFinishTest | 0s', $output);
     }
     finally {
-      self::$loggerStepMethodPrefix = $original_prefix;
+      self::$logStepMethodPrefix = $original_prefix;
     }
   }
 
@@ -364,7 +364,7 @@ final class LoggerTraitTest extends UnitTestCase {
    */
   #[DoesNotPerformAssertions]
   public function testLogStepFinishSilentMode(): void {
-    self::loggerSetVerbose(FALSE);
+    self::logSetVerbose(FALSE);
 
     self::logStepFinish();
     self::logStepFinish('Silent step finish');
@@ -375,7 +375,7 @@ final class LoggerTraitTest extends UnitTestCase {
    */
   #[DoesNotPerformAssertions]
   public function testLogSubstepVerboseMode(): void {
-    self::loggerSetVerbose(TRUE);
+    self::logSetVerbose(TRUE);
 
     self::logSubstep('Processing substep 1');
     self::logSubstep('Processing substep 2');
@@ -386,7 +386,7 @@ final class LoggerTraitTest extends UnitTestCase {
    */
   #[DoesNotPerformAssertions]
   public function testLogSubstepSilentMode(): void {
-    self::loggerSetVerbose(FALSE);
+    self::logSetVerbose(FALSE);
 
     self::logSubstep('Silent substep');
   }
@@ -396,7 +396,7 @@ final class LoggerTraitTest extends UnitTestCase {
    */
   #[DoesNotPerformAssertions]
   public function testLogNoteVerboseMode(): void {
-    self::loggerSetVerbose(TRUE);
+    self::logSetVerbose(TRUE);
 
     self::logNote('Important note about the process');
     self::logNote('Another note with details');
@@ -407,7 +407,7 @@ final class LoggerTraitTest extends UnitTestCase {
    */
   #[DoesNotPerformAssertions]
   public function testLogNoteSilentMode(): void {
-    self::loggerSetVerbose(FALSE);
+    self::logSetVerbose(FALSE);
 
     self::logNote('Silent note');
   }
@@ -416,7 +416,7 @@ final class LoggerTraitTest extends UnitTestCase {
    * Test step logging workflow - with visual output for inspection.
    */
   public function testStepLoggingWorkflow(): void {
-    self::loggerSetVerbose(TRUE);
+    self::logSetVerbose(TRUE);
 
     self::logStepStart('Test workflow');
     self::logSubstep('Initializing');
@@ -442,7 +442,7 @@ final class LoggerTraitTest extends UnitTestCase {
    * With visual output for inspection.
    */
   public function testStepMethodsRespectVerboseMode(): void {
-    self::loggerSetVerbose(FALSE);
+    self::logSetVerbose(FALSE);
     self::logStepStart('Silent step');
     self::logSubstep('Silent substep');
     self::logNote('Silent note');
@@ -456,14 +456,14 @@ final class LoggerTraitTest extends UnitTestCase {
       throw new \RuntimeException('Failed to create memory buffer');
     }
     $this->logBuffer = $buffer;
-    self::loggerSetOutputStream($this->logBuffer);
+    self::logSetOutputStream($this->logBuffer);
 
     // Clear steps tracked by the silent calls to avoid interference.
     $reflection_class = new \ReflectionClass(self::class);
-    $steps_property = $reflection_class->getProperty('loggerSteps');
+    $steps_property = $reflection_class->getProperty('logSteps');
     $steps_property->setValue(NULL, []);
 
-    self::loggerSetVerbose(TRUE);
+    self::logSetVerbose(TRUE);
     self::logStepStart('Verbose step');
     self::logSubstep('Verbose substep');
     self::logNote('Verbose note');
@@ -483,7 +483,7 @@ final class LoggerTraitTest extends UnitTestCase {
    */
   #[DoesNotPerformAssertions]
   public function testElapsedTimeCalculation(): void {
-    self::loggerSetVerbose(TRUE);
+    self::logSetVerbose(TRUE);
 
     self::logStepStart('Timed step');
     // Delay long enough to show measurable elapsed time.
@@ -496,7 +496,7 @@ final class LoggerTraitTest extends UnitTestCase {
    */
   #[DoesNotPerformAssertions]
   public function testLogStepFinishWithoutStart(): void {
-    self::loggerSetVerbose(TRUE);
+    self::logSetVerbose(TRUE);
 
     // A finish without a start shows no elapsed time and does not throw.
     self::logStepFinish('Orphan step');
@@ -507,7 +507,7 @@ final class LoggerTraitTest extends UnitTestCase {
    */
   #[DoesNotPerformAssertions]
   public function testStepRestart(): void {
-    self::loggerSetVerbose(TRUE);
+    self::logSetVerbose(TRUE);
 
     self::logStepStart('First step');
 
@@ -524,10 +524,10 @@ final class LoggerTraitTest extends UnitTestCase {
    */
   #[DoesNotPerformAssertions]
   public function testStepNameMismatch(): void {
-    self::loggerSetVerbose(TRUE);
+    self::logSetVerbose(TRUE);
 
     $reflection_class = new \ReflectionClass(self::class);
-    $steps_property = $reflection_class->getProperty('loggerSteps');
+    $steps_property = $reflection_class->getProperty('logSteps');
 
     $steps_property->setValue(NULL, [
       [
@@ -543,19 +543,19 @@ final class LoggerTraitTest extends UnitTestCase {
   }
 
   /**
-   * Test formatElapsedTime method with various durations.
+   * Test logFormatElapsedTime method with various durations.
    */
   #[DataProvider('dataProviderFormatElapsedTime')]
   public function testFormatElapsedTime(float $input_seconds, string $expected_output): void {
     $reflection_class = new \ReflectionClass(self::class);
-    $method = $reflection_class->getMethod('formatElapsedTime');
+    $method = $reflection_class->getMethod('logFormatElapsedTime');
 
     $result = $method->invoke(NULL, $input_seconds);
     $this->assertSame($expected_output, $result);
   }
 
   /**
-   * Provides test data for formatElapsedTime method.
+   * Provides test data for logFormatElapsedTime method.
    *
    * @return \Iterator<string, array{float, string}>
    *   Test cases: [input_seconds, expected_output]
@@ -575,7 +575,7 @@ final class LoggerTraitTest extends UnitTestCase {
    * Test logStepSummary with no steps tracked.
    */
   public function testLogStepSummaryWithNoSteps(): void {
-    self::loggerSetVerbose(TRUE);
+    self::logSetVerbose(TRUE);
 
     self::logStepSummary();
 
@@ -587,7 +587,7 @@ final class LoggerTraitTest extends UnitTestCase {
    * Test logStepSummary with verbose mode disabled.
    */
   public function testLogStepSummaryWithVerboseDisabled(): void {
-    self::loggerSetVerbose(FALSE);
+    self::logSetVerbose(FALSE);
 
     self::logStepStart('Test step');
     self::logStepFinish('Test step');
@@ -600,7 +600,7 @@ final class LoggerTraitTest extends UnitTestCase {
       throw new \RuntimeException('Failed to create memory buffer');
     }
     $this->logBuffer = $buffer;
-    self::loggerSetOutputStream($this->logBuffer);
+    self::logSetOutputStream($this->logBuffer);
 
     self::logStepSummary();
 
@@ -661,10 +661,10 @@ final class LoggerTraitTest extends UnitTestCase {
    * Test that all steps are tracked in the array.
    */
   public function testStepArrayTracking(): void {
-    self::loggerSetVerbose(TRUE);
+    self::logSetVerbose(TRUE);
 
     $reflection_class = new \ReflectionClass(self::class);
-    $steps_property = $reflection_class->getProperty('loggerSteps');
+    $steps_property = $reflection_class->getProperty('logSteps');
 
     $this->assertEmpty($steps_property->getValue());
 
@@ -695,16 +695,16 @@ final class LoggerTraitTest extends UnitTestCase {
   }
 
   /**
-   * Test loggerSetOutputStream method.
+   * Test logSetOutputStream method.
    */
   public function testLoggerSetOutputStream(): void {
-    self::loggerSetVerbose(TRUE);
+    self::logSetVerbose(TRUE);
 
     $custom_buffer = fopen('php://memory', 'r+');
     if ($custom_buffer === FALSE) {
       throw new \RuntimeException('Failed to create custom buffer');
     }
-    self::loggerSetOutputStream($custom_buffer);
+    self::logSetOutputStream($custom_buffer);
 
     self::log('Custom stream test');
 
@@ -719,30 +719,30 @@ final class LoggerTraitTest extends UnitTestCase {
    * Test output stream fallback to STDERR when set to NULL.
    */
   public function testLoggerOutputStreamFallback(): void {
-    self::loggerSetVerbose(TRUE);
+    self::logSetVerbose(TRUE);
 
-    self::loggerSetOutputStream(NULL);
+    self::logSetOutputStream(NULL);
 
     $reflection_class = new \ReflectionClass(self::class);
-    $method = $reflection_class->getMethod('getOutputStream');
+    $method = $reflection_class->getMethod('logGetOutputStream');
 
     $stream = $method->invoke(NULL);
     $this->assertSame(STDERR, $stream);
   }
 
   /**
-   * Test loggerSetOutputStream validation with invalid input.
+   * Test logSetOutputStream validation with invalid input.
    */
   public function testLoggerSetOutputStreamWithInvalidInput(): void {
     $this->expectException(\InvalidArgumentException::class);
     $this->expectExceptionMessage('Stream must be a valid resource or NULL.');
 
     // @phpstan-ignore-next-line argument.type
-    self::loggerSetOutputStream('invalid_stream');
+    self::logSetOutputStream('invalid_stream');
   }
 
   /**
-   * Test loggerSetOutputStream validation with various invalid types.
+   * Test logSetOutputStream validation with various invalid types.
    */
   public function testLoggerSetOutputStreamWithVariousInvalidTypes(): void {
     $invalid_inputs = [
@@ -756,7 +756,7 @@ final class LoggerTraitTest extends UnitTestCase {
     foreach ($invalid_inputs as $type => $invalid_input) {
       try {
         // @phpstan-ignore-next-line argument.type
-        self::loggerSetOutputStream($invalid_input);
+        self::logSetOutputStream($invalid_input);
         $this->fail(sprintf('Expected InvalidArgumentException for %s input', $type));
       }
       catch (\InvalidArgumentException $e) {
@@ -766,7 +766,7 @@ final class LoggerTraitTest extends UnitTestCase {
   }
 
   /**
-   * Test loggerSetOutputStream accepts valid resource.
+   * Test logSetOutputStream accepts valid resource.
    */
   public function testLoggerSetOutputStreamWithValidResource(): void {
     $valid_resource = fopen('php://memory', 'r+');
@@ -774,10 +774,10 @@ final class LoggerTraitTest extends UnitTestCase {
       throw new \RuntimeException('Failed to create test resource');
     }
 
-    self::loggerSetOutputStream($valid_resource);
+    self::logSetOutputStream($valid_resource);
 
     $reflection_class = new \ReflectionClass(self::class);
-    $method = $reflection_class->getMethod('getOutputStream');
+    $method = $reflection_class->getMethod('logGetOutputStream');
 
     $stream = $method->invoke(NULL);
     $this->assertSame($valid_resource, $stream);
@@ -789,7 +789,7 @@ final class LoggerTraitTest extends UnitTestCase {
    * Test substep and note output formatting.
    */
   public function testSubstepAndNoteOutput(): void {
-    self::loggerSetVerbose(TRUE);
+    self::logSetVerbose(TRUE);
 
     self::logSubstep('Processing data');
     self::logNote('Important detail');
@@ -804,7 +804,7 @@ final class LoggerTraitTest extends UnitTestCase {
    */
   #[DataProvider('dataProviderLoggerMethodsVerboseMode')]
   public function testLoggerMethodsVerboseMode(bool $verbose_mode, string $description, callable $test_method): void {
-    self::loggerSetVerbose($verbose_mode);
+    self::logSetVerbose($verbose_mode);
 
     $test_method(self::class);
 
@@ -844,7 +844,7 @@ final class LoggerTraitTest extends UnitTestCase {
    */
   #[DataProvider('dataProviderStepMethods')]
   public function testStepMethods(string $step_name, ?string $message, array $expected_output): void {
-    self::loggerSetVerbose(TRUE);
+    self::logSetVerbose(TRUE);
 
     if (str_contains($expected_output[0], 'START')) {
       self::logStepStart($message);
@@ -881,14 +881,14 @@ final class LoggerTraitTest extends UnitTestCase {
    */
   #[DataProvider('dataProviderSectionFormatting')]
   public function testSectionFormatting(string $title, ?string $message, bool $double_border, int $min_width, array $expected_strings): void {
-    self::loggerSetVerbose(TRUE);
+    self::logSetVerbose(TRUE);
 
     $buffer = fopen('php://memory', 'r+');
     if ($buffer === FALSE) {
       throw new \RuntimeException('Failed to create memory buffer');
     }
     $this->logBuffer = $buffer;
-    self::loggerSetOutputStream($this->logBuffer);
+    self::logSetOutputStream($this->logBuffer);
 
     self::logSection($title, $message, $double_border, $min_width);
 
@@ -933,12 +933,12 @@ final class LoggerTraitTest extends UnitTestCase {
    * Test hierarchical step tracking with parent stack.
    */
   public function testHierarchicalStepTracking(): void {
-    self::loggerSetVerbose(TRUE);
+    self::logSetVerbose(TRUE);
 
     $reflection_class = new \ReflectionClass(self::class);
-    $steps_property = $reflection_class->getProperty('loggerSteps');
+    $steps_property = $reflection_class->getProperty('logSteps');
 
-    $stack_property = $reflection_class->getProperty('loggerStepStack');
+    $stack_property = $reflection_class->getProperty('logStepStack');
 
     self::logStepStart('Level 1');
     $steps = $steps_property->getValue();
@@ -1036,13 +1036,13 @@ final class LoggerTraitTest extends UnitTestCase {
   }
 
   /**
-   * Test loggerInfo method.
+   * Test logInfo method.
    */
   public function testLoggerInfo(): void {
     self::logStepStart('TestStep');
     self::logStepFinish('TestStep');
 
-    $info = $this->loggerInfo();
+    $info = $this->logInfo();
 
     $this->assertStringContainsString('STEP SUMMARY', $info);
     $this->assertStringContainsString('testLoggerInfo', $info);
@@ -1050,10 +1050,10 @@ final class LoggerTraitTest extends UnitTestCase {
   }
 
   /**
-   * Test loggerInfo with no steps.
+   * Test logInfo with no steps.
    */
   public function testLoggerInfoEmpty(): void {
-    $info = $this->loggerInfo();
+    $info = $this->logInfo();
 
     $this->assertStringContainsString('STEP SUMMARY', $info);
     $this->assertSame("STEP SUMMARY\n", $info);

--- a/tests/Unit/ProcessTraitTest.php
+++ b/tests/Unit/ProcessTraitTest.php
@@ -19,7 +19,7 @@ final class ProcessTraitTest extends UnitTestCase {
 
   protected function setUp(): void {
     parent::setUp();
-    $this->processStreamOutput = FALSE;
+    $this->processStreamingOutput = FALSE;
   }
 
   protected function tearDown(): void {
@@ -481,7 +481,7 @@ final class ProcessTraitTest extends UnitTestCase {
 
     // Override processStreamingOutputCallback method temporarily.
     $reflection = new \ReflectionClass($this);
-    $property = $reflection->getProperty('processStreamOutput');
+    $property = $reflection->getProperty('processStreamingOutput');
     $property->setValue($this, TRUE);
 
     // Capture streaming output by overriding the actual method.
@@ -1344,7 +1344,7 @@ EOL;
   }
 
   public function testStreamingOutputWithDimmingEnabled(): void {
-    $this->processStreamOutput = TRUE;
+    $this->processStreamingOutput = TRUE;
     self::$processStreamingOutputShouldDim = TRUE;
 
     $temp_file = tempnam(sys_get_temp_dir(), 'phpunit_stdout_test');
@@ -1358,7 +1358,7 @@ class TestClass {
   use ProcessTrait;
   
   public function enableStreamingWithDimming() {
-    $this->processStreamOutput = true;
+    $this->processStreamingOutput = true;
     static::$processStreamingOutputShouldDim = true;
   }
 }
@@ -1379,11 +1379,11 @@ $test->processRun("echo", ["test output"]);
     $this->assertStringContainsString("\033[22m", $output, 'Should contain ANSI dim end code');
     $this->assertStringContainsString('test output', $output, 'Should contain actual text');
 
-    $this->processStreamOutput = FALSE;
+    $this->processStreamingOutput = FALSE;
   }
 
   public function testStreamingOutputWithDimmingDisabled(): void {
-    $this->processStreamOutput = TRUE;
+    $this->processStreamingOutput = TRUE;
     self::$processStreamingOutputShouldDim = FALSE;
 
     $temp_file = tempnam(sys_get_temp_dir(), 'phpunit_stdout_test');
@@ -1397,7 +1397,7 @@ class TestClass {
   use ProcessTrait;
   
   public function enableStreamingWithoutDimming() {
-    $this->processStreamOutput = true;
+    $this->processStreamingOutput = true;
     static::$processStreamingOutputShouldDim = false;
   }
 }
@@ -1418,7 +1418,7 @@ $test->processRun("echo", ["test output"]);
     $this->assertStringNotContainsString("\033[22m", $output, 'Should not contain ANSI dim end code');
     $this->assertStringContainsString('test output', $output, 'Should contain actual text');
 
-    $this->processStreamOutput = FALSE;
+    $this->processStreamingOutput = FALSE;
     self::$processStreamingOutputShouldDim = TRUE;
   }
 
@@ -1435,7 +1435,7 @@ $test->processRun("echo", ["test output"]);
 
   #[DataProvider('dataProviderDim')]
   public function testDim(string $text, string $eol, string $expected): void {
-    $this->assertSame($expected, self::dim($text, $eol));
+    $this->assertSame($expected, self::processColorDim($text, $eol));
   }
 
   public static function dataProviderDim(): \Iterator {


### PR DESCRIPTION
> Stacked on #105. Review that one first; this PR's diff is only its own change.

## Summary

Every method and property declared in a trait now starts with that trait's prefix, so members remain traceable to their trait once composed into a consuming class. The rule is recorded in `AGENTS.md` along with its exceptions, so a future consistency pass does not undo any of it.

Most traits already complied. This PR fixes the ones that did not.

## Changes

`LoggerTrait` mixed three schemes: `log*` on 8 output methods, `logger*` on 3 configuration methods and all 5 properties, and no prefix at all on 2 helpers. It now uses `log` consistently.

| Before | After |
|---|---|
| `loggerSetVerbose()` | `logSetVerbose()` |
| `loggerSetOutputStream()` | `logSetOutputStream()` |
| `loggerInfo()` | `logInfo()` |
| `getOutputStream()` | `logGetOutputStream()` |
| `formatElapsedTime()` | `logFormatElapsedTime()` |
| `$loggerIsVerbose` | `$logIsVerbose` |
| `$loggerOutputStream` | `$logOutputStream` |
| `$loggerSteps` | `$logSteps` |
| `$loggerStepStack` | `$logStepStack` |
| `$loggerStepMethodPrefix` | `$logStepMethodPrefix` |

The 8 existing `log*` methods are unchanged.

`ProcessTrait` had one unprefixed member and one inconsistent property:

| Before | After |
|---|---|
| `dim()` | `processColorDim()` |
| `$processStreamOutput` | `$processStreamingOutput` |

## Documented exceptions

`AGENTS.md` records four, so they are not "fixed" later:

- **Assertion methods keep the PHPUnit `assert` prefix first**, with the trait's subject after it, so they group with PHPUnit's own assertions in autocomplete.
- **`LoggerTrait` uses `log`, not `logger`**, applied consistently.
- **`SerializableClosureTrait` keeps `cw()` and `cu()`.** The short names exist so data-provider lines stay within the line limit; the trait docblock explains this.
- **`ReflectionTrait` keeps `callProtectedMethod()` and friends.** They read naturally at the call site and are in wide use.

`LocationsTrait`'s `$root`, `$fixtures`, `$workspace`, `$repo`, `$sut` and `$tmp` are also left unprefixed, since consuming suites read them directly as `self::$fixtures` and `self::$tmp`. The accessors `locationsRoot()`, `locationsFixtures()` and the rest already follow the rule.

## Breaking change

All renames above are public API. Consumers update names only; no signature, argument order or parameter name changes.

## Test plan

- [x] `composer test` green: 469 tests
- [x] `composer lint` green: PHPCS, PHPStan level 9, Rector
- [x] Audited every renamed identifier for leakage into comments and string literals, parsing with `token_get_all()` so only comments and strings were inspected. All occurrences are legitimate: reflection name strings, provider keys, and docblocks naming the method under test.

## Before / After

```
┌─ BEFORE ─────────────────────────────────────────────────────┐
│  LoggerTrait   log*     8 methods                            │
│                logger*  3 methods, 5 properties              │
│                (none)   2 helpers                            │
│                                                              │
│  ProcessTrait  dim()                  no prefix              │
│                $processStreamOutput   inconsistent with      │
│                                       $processStreaming*     │
│                                                              │
│  no written rule; drift returns with the next change         │
└──────────────────────────────────────────────────────────────┘
                               │
                               ▼
┌─ AFTER ──────────────────────────────────────────────────────┐
│  LoggerTrait   log*     everything, methods and properties   │
│                                                              │
│  ProcessTrait  processColorDim()                             │
│                $processStreamingOutput                       │
│                                                              │
│  AGENTS.md states the rule and its four exceptions           │
└──────────────────────────────────────────────────────────────┘
```
