### PR TITLE
Settled failure message punctuation across the traits.

### DIFF
--- a/src/Traits/ApplicationTrait.php
+++ b/src/Traits/ApplicationTrait.php
@@ -99,7 +99,7 @@ trait ApplicationTrait {
    */
   public function applicationInitFromLoader(string $loader_path): ApplicationTester {
     if (!file_exists($loader_path)) {
-      throw new \InvalidArgumentException(sprintf('Loader file not found: %s', $loader_path));
+      throw new \InvalidArgumentException(sprintf('Loader file not found: %s.', $loader_path));
     }
 
     // Validate before assigning: the property is typed, so assigning a wrong
@@ -107,7 +107,7 @@ trait ApplicationTrait {
     $application = require $loader_path;
 
     if (!$application instanceof Application) {
-      throw new \InvalidArgumentException('Loader must return an instance of Application');
+      throw new \InvalidArgumentException('Loader must return an instance of Application.');
     }
 
     $this->application = $application;
@@ -150,7 +150,7 @@ trait ApplicationTrait {
 
     $instance = is_object($object_or_class) ? $object_or_class : new $object_or_class();
     if (!$instance instanceof Command) {
-      throw new \InvalidArgumentException('The provided object is not an instance of Command');
+      throw new \InvalidArgumentException('The provided object is not an instance of Command.');
     }
 
     $this->application->add($instance);
@@ -158,7 +158,7 @@ trait ApplicationTrait {
     $name = $instance->getName();
     if ($name === NULL) {
       // @codeCoverageIgnoreStart
-      throw new \InvalidArgumentException('Command name cannot be null after being added to application');
+      throw new \InvalidArgumentException('Command name cannot be null after being added to application.');
       // @codeCoverageIgnoreEnd
     }
     $this->application->setDefaultCommand($name, $is_single_command);
@@ -267,7 +267,7 @@ trait ApplicationTrait {
    *   Optional failure message.
    */
   public function assertApplicationSuccessful(?string $message = NULL): void {
-    $this->assertNotNull($this->applicationTester, $message ?: 'Application is not initialized');
+    $this->assertNotNull($this->applicationTester, $message ?: 'Application is not initialized.');
     $this->assertSame(0, $this->applicationTester->getStatusCode(), $message ?: sprintf(
       'Application failed with exit code %d: %s%sOutput:%s%s',
       $this->applicationTester->getStatusCode(),
@@ -285,7 +285,7 @@ trait ApplicationTrait {
    *   Optional failure message.
    */
   public function assertApplicationFailed(?string $message = NULL): void {
-    $this->assertNotNull($this->applicationTester, $message ?: 'Application is not initialized');
+    $this->assertNotNull($this->applicationTester, $message ?: 'Application is not initialized.');
     $this->assertNotSame(0, $this->applicationTester->getStatusCode(), $message ?: sprintf(
       'Application succeeded when failure was expected.%sOutput:%s%s',
       PHP_EOL,
@@ -303,7 +303,7 @@ trait ApplicationTrait {
    *   Optional failure message.
    */
   public function assertApplicationOutputContains(array|string $expected, ?string $message = NULL): void {
-    $this->assertNotNull($this->applicationTester, $message ?: 'Application is not initialized');
+    $this->assertNotNull($this->applicationTester, $message ?: 'Application is not initialized.');
     $output = $this->applicationTester->getDisplay();
 
     $expected = is_array($expected) ? $expected : [$expected];
@@ -330,7 +330,7 @@ trait ApplicationTrait {
    *   Optional failure message.
    */
   public function assertApplicationOutputNotContains(array|string $expected, ?string $message = NULL): void {
-    $this->assertNotNull($this->applicationTester, $message ?: 'Application is not initialized');
+    $this->assertNotNull($this->applicationTester, $message ?: 'Application is not initialized.');
     $output = $this->applicationTester->getDisplay();
 
     $expected = is_array($expected) ? $expected : [$expected];
@@ -357,7 +357,7 @@ trait ApplicationTrait {
    *   Optional failure message.
    */
   public function assertApplicationErrorOutputContains(array|string $expected, ?string $message = NULL): void {
-    $this->assertNotNull($this->applicationTester, $message ?: 'Application is not initialized');
+    $this->assertNotNull($this->applicationTester, $message ?: 'Application is not initialized.');
     $output = $this->applicationTester->getErrorOutput();
 
     $expected = is_array($expected) ? $expected : [$expected];
@@ -384,7 +384,7 @@ trait ApplicationTrait {
    *   Optional failure message.
    */
   public function assertApplicationErrorOutputNotContains(array|string $expected, ?string $message = NULL): void {
-    $this->assertNotNull($this->applicationTester, $message ?: 'Application is not initialized');
+    $this->assertNotNull($this->applicationTester, $message ?: 'Application is not initialized.');
     $output = $this->applicationTester->getErrorOutput();
 
     $expected = is_array($expected) ? $expected : [$expected];
@@ -429,7 +429,7 @@ trait ApplicationTrait {
    *   When prefix usage is inconsistent (some have prefixes, others don't).
    */
   public function assertApplicationOutputContainsOrNot(array|string $expected, ?string $message = NULL): void {
-    $this->assertNotNull($this->applicationTester, $message ?: 'Application is not initialized');
+    $this->assertNotNull($this->applicationTester, $message ?: 'Application is not initialized.');
 
     $output = $this->applicationTester->getDisplay();
     // Trim trailing whitespace for more intuitive exact matching.
@@ -472,7 +472,7 @@ trait ApplicationTrait {
    *   When prefix usage is inconsistent (some have prefixes, others don't).
    */
   public function assertApplicationErrorOutputContainsOrNot(array|string $expected, ?string $message = NULL): void {
-    $this->assertNotNull($this->applicationTester, $message ?: 'Application is not initialized');
+    $this->assertNotNull($this->applicationTester, $message ?: 'Application is not initialized.');
 
     $output = $this->applicationTester->getErrorOutput();
     // Trim trailing whitespace for more intuitive exact matching.
@@ -499,7 +499,7 @@ trait ApplicationTrait {
    *   Optional failure message.
    */
   public function assertApplicationAnyOutputContains(array|string $expected, ?string $message = NULL): void {
-    $this->assertNotNull($this->applicationTester, $message ?: 'Application is not initialized');
+    $this->assertNotNull($this->applicationTester, $message ?: 'Application is not initialized.');
     $output = $this->applicationTester->getDisplay() . $this->applicationTester->getErrorOutput();
 
     $expected = is_array($expected) ? $expected : [$expected];
@@ -526,7 +526,7 @@ trait ApplicationTrait {
    *   Optional failure message.
    */
   public function assertApplicationAnyOutputNotContains(array|string $expected, ?string $message = NULL): void {
-    $this->assertNotNull($this->applicationTester, $message ?: 'Application is not initialized');
+    $this->assertNotNull($this->applicationTester, $message ?: 'Application is not initialized.');
     $output = $this->applicationTester->getDisplay() . $this->applicationTester->getErrorOutput();
 
     $expected = is_array($expected) ? $expected : [$expected];
@@ -572,7 +572,7 @@ trait ApplicationTrait {
    *   When prefix usage is inconsistent (some have prefixes, others don't).
    */
   public function assertApplicationAnyOutputContainsOrNot(array|string $expected, ?string $message = NULL): void {
-    $this->assertNotNull($this->applicationTester, $message ?: 'Application is not initialized');
+    $this->assertNotNull($this->applicationTester, $message ?: 'Application is not initialized.');
 
     $output = $this->applicationTester->getDisplay();
     $output .= $this->applicationTester->getErrorOutput();

--- a/src/Traits/ProcessTrait.php
+++ b/src/Traits/ProcessTrait.php
@@ -81,7 +81,7 @@ trait ProcessTrait {
    */
   public function processGet(): Process {
     if (!$this->process instanceof Process) {
-      throw new \RuntimeException('Process is not initialized');
+      throw new \RuntimeException('Process is not initialized.');
     }
     return $this->process;
   }
@@ -370,7 +370,7 @@ trait ProcessTrait {
    *   Optional message to include in the failure output if the process failed.
    */
   public function assertProcessSuccessful(?string $message = NULL): void {
-    $this->assertNotNull($this->process, 'Process is not initialized');
+    $this->assertNotNull($this->process, 'Process is not initialized.');
 
     if (!$this->process->isSuccessful()) {
       $this->fail('PROCESS FAILED' . PHP_EOL . ($message ? 'Message: ' . $message . PHP_EOL : '') . $this->processFormatOutput() . $this->assertionSuffix());
@@ -388,7 +388,7 @@ trait ProcessTrait {
    *   succeeded.
    */
   public function assertProcessFailed(?string $message = NULL): void {
-    $this->assertNotNull($this->process, 'Process is not initialized');
+    $this->assertNotNull($this->process, 'Process is not initialized.');
 
     if ($this->process->isSuccessful()) {
       $this->fail('PROCESS SUCCEEDED but failure was expected' . PHP_EOL . ($message ? 'Message: ' . $message . PHP_EOL : '') . $this->processFormatOutput() . $this->assertionSuffix());
@@ -403,7 +403,7 @@ trait ProcessTrait {
    */
   protected function processFormatOutput(): string {
     if (!$this->process instanceof Process) {
-      return 'Process is not initialized' . PHP_EOL;
+      return 'Process is not initialized.' . PHP_EOL;
     }
 
     $process_output = $this->process->getOutput();
@@ -436,7 +436,7 @@ trait ProcessTrait {
    *   Optional failure message.
    */
   public function assertProcessOutputContains(array|string $expected, ?string $message = NULL): void {
-    $this->assertNotNull($this->process, 'Process is not initialized');
+    $this->assertNotNull($this->process, 'Process is not initialized.');
     $output = $this->process->getOutput();
 
     $expected = is_array($expected) ? $expected : [$expected];
@@ -463,7 +463,7 @@ trait ProcessTrait {
    *   Optional failure message.
    */
   public function assertProcessOutputNotContains(array|string $expected, ?string $message = NULL): void {
-    $this->assertNotNull($this->process, 'Process is not initialized');
+    $this->assertNotNull($this->process, 'Process is not initialized.');
     $output = $this->process->getOutput();
 
     $expected = is_array($expected) ? $expected : [$expected];
@@ -490,7 +490,7 @@ trait ProcessTrait {
    *   Optional failure message.
    */
   public function assertProcessErrorOutputContains(array|string $expected, ?string $message = NULL): void {
-    $this->assertNotNull($this->process, 'Process is not initialized');
+    $this->assertNotNull($this->process, 'Process is not initialized.');
     $output = $this->process->getErrorOutput();
 
     $expected = is_array($expected) ? $expected : [$expected];
@@ -517,7 +517,7 @@ trait ProcessTrait {
    *   Optional failure message.
    */
   public function assertProcessErrorOutputNotContains(array|string $expected, ?string $message = NULL): void {
-    $this->assertNotNull($this->process, 'Process is not initialized');
+    $this->assertNotNull($this->process, 'Process is not initialized.');
     $output = $this->process->getErrorOutput();
 
     $expected = is_array($expected) ? $expected : [$expected];
@@ -562,7 +562,7 @@ trait ProcessTrait {
    *   When prefix usage is inconsistent (some have prefixes, others don't).
    */
   public function assertProcessOutputContainsOrNot(array|string $expected, ?string $message = NULL): void {
-    $this->assertNotNull($this->process, 'Process is not initialized');
+    $this->assertNotNull($this->process, 'Process is not initialized.');
 
     $output = $this->process->getOutput();
     // Trim trailing whitespace for more intuitive exact matching.
@@ -605,7 +605,7 @@ trait ProcessTrait {
    *   When prefix usage is inconsistent (some have prefixes, others don't).
    */
   public function assertProcessErrorOutputContainsOrNot(array|string $expected, ?string $message = NULL): void {
-    $this->assertNotNull($this->process, 'Process is not initialized');
+    $this->assertNotNull($this->process, 'Process is not initialized.');
 
     $output = $this->process->getErrorOutput();
     // Trim trailing whitespace for more intuitive exact matching.
@@ -632,7 +632,7 @@ trait ProcessTrait {
    *   Optional failure message.
    */
   public function assertProcessAnyOutputContains(array|string $expected, ?string $message = NULL): void {
-    $this->assertNotNull($this->process, 'Process is not initialized');
+    $this->assertNotNull($this->process, 'Process is not initialized.');
 
     $output = $this->process->getOutput();
     $output .= $this->process->getErrorOutput();
@@ -663,7 +663,7 @@ trait ProcessTrait {
    *   Optional failure message.
    */
   public function assertProcessAnyOutputNotContains(array|string $expected, ?string $message = NULL): void {
-    $this->assertNotNull($this->process, 'Process is not initialized');
+    $this->assertNotNull($this->process, 'Process is not initialized.');
 
     $output = $this->process->getOutput();
     $output .= $this->process->getErrorOutput();
@@ -711,7 +711,7 @@ trait ProcessTrait {
    *   When prefix usage is inconsistent (some have prefixes, others don't).
    */
   public function assertProcessAnyOutputContainsOrNot(array|string $expected, ?string $message = NULL): void {
-    $this->assertNotNull($this->process, 'Process is not initialized');
+    $this->assertNotNull($this->process, 'Process is not initialized.');
 
     $output = $this->process->getOutput();
     $output .= $this->process->getErrorOutput();

--- a/src/Traits/ReflectionTrait.php
+++ b/src/Traits/ReflectionTrait.php
@@ -33,13 +33,13 @@ trait ReflectionTrait {
     $object_or_class = is_object($object) ? $object::class : $object;
 
     if (!class_exists($object_or_class)) {
-      throw new \InvalidArgumentException(sprintf('Class %s does not exist', $object_or_class));
+      throw new \InvalidArgumentException(sprintf('Class %s does not exist.', $object_or_class));
     }
 
     $class = new \ReflectionClass($object_or_class);
 
     if (!$class->hasMethod($name)) {
-      throw new \InvalidArgumentException(sprintf('Method %s does not exist', $name));
+      throw new \InvalidArgumentException(sprintf('Method %s does not exist.', $name));
     }
 
     $method = $class->getMethod($name);
@@ -47,7 +47,7 @@ trait ReflectionTrait {
     $invoke_object = $method->isStatic() ? NULL : (is_object($object) ? $object : NULL);
 
     if (!$method->isStatic() && $invoke_object === NULL) {
-      throw new \InvalidArgumentException('An object instance is required for non-static methods');
+      throw new \InvalidArgumentException('An object instance is required for non-static methods.');
     }
 
     return $method->invokeArgs($invoke_object, $args);

--- a/src/Traits/StringTrait.php
+++ b/src/Traits/StringTrait.php
@@ -73,12 +73,12 @@ trait StringTrait {
 
     foreach ($prefixes as $prefix) {
       if (strlen($prefix) !== 1) {
-        throw new \InvalidArgumentException('All prefix arguments must be exactly one character long');
+        throw new \InvalidArgumentException('All prefix arguments must be exactly one character long.');
       }
     }
 
     if (count(array_unique($prefixes)) !== 4) {
-      throw new \InvalidArgumentException('All prefix arguments must be unique');
+      throw new \InvalidArgumentException('All prefix arguments must be unique.');
     }
 
     $expected = is_array($expected) ? $expected : [$expected];
@@ -128,7 +128,7 @@ trait StringTrait {
           break;
         }
       }
-      throw new \RuntimeException(sprintf('All strings must have valid prefixes in mixed mode. First invalid: "%s"', $first_invalid));
+      throw new \RuntimeException(sprintf('All strings must have valid prefixes in mixed mode. First invalid: "%s".', $first_invalid));
     }
 
     foreach ($expected as $expected_value) {
@@ -152,7 +152,7 @@ trait StringTrait {
         }
 
         if ($value === '') {
-          throw new \RuntimeException(sprintf('Value cannot be empty after stripping prefix: "%s"', $expected_value));
+          throw new \RuntimeException(sprintf('Value cannot be empty after stripping prefix: "%s".', $expected_value));
         }
       }
       else {

--- a/src/Traits/TuiTrait.php
+++ b/src/Traits/TuiTrait.php
@@ -135,7 +135,7 @@ trait TuiTrait {
   public static function tuiEntries(array $entries, string $default = ''): array {
     foreach ($entries as $key => $value) {
       if (!is_scalar($value)) {
-        throw new \InvalidArgumentException(sprintf('TUI entry "%s" must be a scalar value. Got: %s', $key, gettype($value)));
+        throw new \InvalidArgumentException(sprintf('TUI entry "%s" must be a scalar value. Got: %s.', $key, gettype($value)));
       }
 
       if ($value === static::TUI_SKIP) {

--- a/tests/Unit/ApplicationTraitTest.php
+++ b/tests/Unit/ApplicationTraitTest.php
@@ -60,7 +60,7 @@ final class ApplicationTraitTest extends UnitTestCase {
     file_put_contents($temp_file, '<?php return ' . $returned . ';');
 
     $this->expectException(\InvalidArgumentException::class);
-    $this->expectExceptionMessage('Loader must return an instance of Application');
+    $this->expectExceptionMessage('Loader must return an instance of Application.');
 
     $this->applicationInitFromLoader($temp_file);
   }
@@ -95,7 +95,7 @@ final class ApplicationTraitTest extends UnitTestCase {
 
   public function testApplicationInitFromCommandInvalidClass(): void {
     $this->expectException(\InvalidArgumentException::class);
-    $this->expectExceptionMessage('The provided object is not an instance of Command');
+    $this->expectExceptionMessage('The provided object is not an instance of Command.');
 
     $this->applicationInitFromCommand(\stdClass::class);
   }
@@ -273,7 +273,7 @@ final class ApplicationTraitTest extends UnitTestCase {
 
   public function testApplicationRunWithoutInit(): void {
     $this->expectException(\RuntimeException::class);
-    $this->expectExceptionMessage('Application is not initialized');
+    $this->expectExceptionMessage('Application is not initialized.');
 
     $this->applicationRun([]);
   }
@@ -495,7 +495,7 @@ final class ApplicationTraitTest extends UnitTestCase {
     $this->applicationTester = NULL;
 
     $this->expectException(ExpectationFailedException::class);
-    $this->expectExceptionMessage('Application is not initialized');
+    $this->expectExceptionMessage('Application is not initialized.');
 
     $this->assertApplicationSuccessful();
   }
@@ -504,7 +504,7 @@ final class ApplicationTraitTest extends UnitTestCase {
     $this->applicationTester = NULL;
 
     $this->expectException(ExpectationFailedException::class);
-    $this->expectExceptionMessage('Application is not initialized');
+    $this->expectExceptionMessage('Application is not initialized.');
 
     $this->assertApplicationFailed();
   }
@@ -513,7 +513,7 @@ final class ApplicationTraitTest extends UnitTestCase {
     $this->applicationTester = NULL;
 
     $this->expectException(ExpectationFailedException::class);
-    $this->expectExceptionMessage('Application is not initialized');
+    $this->expectExceptionMessage('Application is not initialized.');
 
     $this->assertApplicationOutputContains('test');
   }
@@ -522,7 +522,7 @@ final class ApplicationTraitTest extends UnitTestCase {
     $this->applicationTester = NULL;
 
     $this->expectException(ExpectationFailedException::class);
-    $this->expectExceptionMessage('Application is not initialized');
+    $this->expectExceptionMessage('Application is not initialized.');
 
     $this->assertApplicationOutputNotContains('test');
   }
@@ -531,7 +531,7 @@ final class ApplicationTraitTest extends UnitTestCase {
     $this->applicationTester = NULL;
 
     $this->expectException(ExpectationFailedException::class);
-    $this->expectExceptionMessage('Application is not initialized');
+    $this->expectExceptionMessage('Application is not initialized.');
 
     $this->assertApplicationErrorOutputContains('test');
   }
@@ -540,7 +540,7 @@ final class ApplicationTraitTest extends UnitTestCase {
     $this->applicationTester = NULL;
 
     $this->expectException(ExpectationFailedException::class);
-    $this->expectExceptionMessage('Application is not initialized');
+    $this->expectExceptionMessage('Application is not initialized.');
 
     $this->assertApplicationErrorOutputNotContains('test');
   }
@@ -549,7 +549,7 @@ final class ApplicationTraitTest extends UnitTestCase {
     $this->applicationTester = NULL;
 
     $this->expectException(ExpectationFailedException::class);
-    $this->expectExceptionMessage('Application is not initialized');
+    $this->expectExceptionMessage('Application is not initialized.');
 
     $this->assertApplicationOutputContainsOrNot('test');
   }
@@ -558,7 +558,7 @@ final class ApplicationTraitTest extends UnitTestCase {
     $this->applicationTester = NULL;
 
     $this->expectException(ExpectationFailedException::class);
-    $this->expectExceptionMessage('Application is not initialized');
+    $this->expectExceptionMessage('Application is not initialized.');
 
     $this->assertApplicationErrorOutputContainsOrNot('test');
   }
@@ -567,7 +567,7 @@ final class ApplicationTraitTest extends UnitTestCase {
     $this->applicationTester = NULL;
 
     $this->expectException(ExpectationFailedException::class);
-    $this->expectExceptionMessage('Application is not initialized');
+    $this->expectExceptionMessage('Application is not initialized.');
 
     $this->assertApplicationAnyOutputContainsOrNot('test');
   }

--- a/tests/Unit/ProcessTraitTest.php
+++ b/tests/Unit/ProcessTraitTest.php
@@ -369,7 +369,7 @@ final class ProcessTraitTest extends UnitTestCase {
     $this->process = NULL;
 
     $this->expectException(ExpectationFailedException::class);
-    $this->expectExceptionMessage('Process is not initialized');
+    $this->expectExceptionMessage('Process is not initialized.');
 
     $this->assertProcessSuccessful();
   }
@@ -378,7 +378,7 @@ final class ProcessTraitTest extends UnitTestCase {
     $this->process = NULL;
 
     $this->expectException(ExpectationFailedException::class);
-    $this->expectExceptionMessage('Process is not initialized');
+    $this->expectExceptionMessage('Process is not initialized.');
 
     $this->assertProcessFailed();
   }
@@ -387,7 +387,7 @@ final class ProcessTraitTest extends UnitTestCase {
     $this->process = NULL;
 
     $this->expectException(ExpectationFailedException::class);
-    $this->expectExceptionMessage('Process is not initialized');
+    $this->expectExceptionMessage('Process is not initialized.');
 
     $this->assertProcessOutputContains('test');
   }
@@ -396,7 +396,7 @@ final class ProcessTraitTest extends UnitTestCase {
     $this->process = NULL;
 
     $this->expectException(ExpectationFailedException::class);
-    $this->expectExceptionMessage('Process is not initialized');
+    $this->expectExceptionMessage('Process is not initialized.');
 
     $this->assertProcessOutputNotContains('test');
   }
@@ -405,7 +405,7 @@ final class ProcessTraitTest extends UnitTestCase {
     $this->process = NULL;
 
     $this->expectException(ExpectationFailedException::class);
-    $this->expectExceptionMessage('Process is not initialized');
+    $this->expectExceptionMessage('Process is not initialized.');
 
     $this->assertProcessErrorOutputContains('test');
   }
@@ -414,7 +414,7 @@ final class ProcessTraitTest extends UnitTestCase {
     $this->process = NULL;
 
     $this->expectException(ExpectationFailedException::class);
-    $this->expectExceptionMessage('Process is not initialized');
+    $this->expectExceptionMessage('Process is not initialized.');
 
     $this->assertProcessErrorOutputNotContains('test');
   }
@@ -423,7 +423,7 @@ final class ProcessTraitTest extends UnitTestCase {
     $this->process = NULL;
 
     $this->expectException(ExpectationFailedException::class);
-    $this->expectExceptionMessage('Process is not initialized');
+    $this->expectExceptionMessage('Process is not initialized.');
 
     $this->assertProcessOutputContainsOrNot('test');
   }
@@ -432,7 +432,7 @@ final class ProcessTraitTest extends UnitTestCase {
     $this->process = NULL;
 
     $this->expectException(ExpectationFailedException::class);
-    $this->expectExceptionMessage('Process is not initialized');
+    $this->expectExceptionMessage('Process is not initialized.');
 
     $this->assertProcessErrorOutputContainsOrNot('test');
   }
@@ -441,7 +441,7 @@ final class ProcessTraitTest extends UnitTestCase {
     $this->process = NULL;
 
     $this->expectException(ExpectationFailedException::class);
-    $this->expectExceptionMessage('Process is not initialized');
+    $this->expectExceptionMessage('Process is not initialized.');
 
     $this->assertProcessAnyOutputContains('test');
   }
@@ -450,7 +450,7 @@ final class ProcessTraitTest extends UnitTestCase {
     $this->process = NULL;
 
     $this->expectException(ExpectationFailedException::class);
-    $this->expectExceptionMessage('Process is not initialized');
+    $this->expectExceptionMessage('Process is not initialized.');
 
     $this->assertProcessAnyOutputNotContains('test');
   }
@@ -459,7 +459,7 @@ final class ProcessTraitTest extends UnitTestCase {
     $this->process = NULL;
 
     $this->expectException(ExpectationFailedException::class);
-    $this->expectExceptionMessage('Process is not initialized');
+    $this->expectExceptionMessage('Process is not initialized.');
 
     $this->assertProcessAnyOutputContainsOrNot('test');
   }
@@ -603,7 +603,7 @@ EOL;
 
   public function testProcessGetWhenNotInitialized(): void {
     $this->expectException(\RuntimeException::class);
-    $this->expectExceptionMessage('Process is not initialized');
+    $this->expectExceptionMessage('Process is not initialized.');
 
     $this->processGet();
   }
@@ -659,7 +659,7 @@ EOL;
     $formatted_output = $method->invoke($this);
     $this->assertIsString($formatted_output);
 
-    $this->assertStringContainsString('Process is not initialized', $formatted_output);
+    $this->assertStringContainsString('Process is not initialized.', $formatted_output);
   }
 
   public function testProcessStreamingCallbackWithEmptyBuffer(): void {
@@ -941,7 +941,7 @@ EOL;
     $result = $method->invoke($this);
 
     $this->assertIsString($result);
-    $this->assertStringContainsString('Process is not initialized', $result);
+    $this->assertStringContainsString('Process is not initialized.', $result);
   }
 
   public function testStaticVariableAccess(): void {

--- a/tests/Unit/ReflectionTraitTest.php
+++ b/tests/Unit/ReflectionTraitTest.php
@@ -64,7 +64,7 @@ final class ReflectionTraitTest extends TestCase {
 
   public function testCallProtectedMethodWithInvalidObject(): void {
     $this->expectException(\InvalidArgumentException::class);
-    $this->expectExceptionMessage('An object instance is required for non-static methods');
+    $this->expectExceptionMessage('An object instance is required for non-static methods.');
 
     self::callProtectedMethod($this->testObject::class, 'protectedMethod', ['test']);
   }

--- a/tests/Unit/StringTraitTest.php
+++ b/tests/Unit/StringTraitTest.php
@@ -172,7 +172,7 @@ final class StringTraitTest extends UnitTestCase {
       ['++', '*', '-', '!', ' '],
       ['Expected exact match for "%s" in haystack', 'Expected substring "%s" in haystack', 'Expected no exact match for "%s" in haystack', 'Expected substring "%s" not in haystack'],
       \InvalidArgumentException::class,
-      'All prefix arguments must be exactly one character long',
+      'All prefix arguments must be exactly one character long.',
     ];
     yield 'non_unique_prefixes' => [
       'non_unique_prefixes',
@@ -182,7 +182,7 @@ final class StringTraitTest extends UnitTestCase {
       ['+', '+', '-', '!', ' '],
       ['Expected exact match for "%s" in haystack', 'Expected substring "%s" in haystack', 'Expected no exact match for "%s" in haystack', 'Expected substring "%s" not in haystack'],
       \InvalidArgumentException::class,
-      'All prefix arguments must be unique',
+      'All prefix arguments must be unique.',
     ];
     yield 'inconsistent_prefix_usage' => [
       'inconsistent_prefix_usage',


### PR DESCRIPTION
> Stacked on #106. Review that one first; this PR's diff is only its own change.

## Summary

Failure and exception messages ended with a period in about half the codebase and without one in the other half, with both spellings sometimes inside the same trait. This settles them all on a trailing period.

The split was genuinely even, so there was no majority to converge on mechanically. A period is the choice here because these strings are full sentences shown to a developer reading a failure report.

## Changes

Trailing periods added to messages in `ProcessTrait`, `ApplicationTrait`, `StringTrait`, `ReflectionTrait` and `TuiTrait`, covering both thrown exception messages and the templates used for assertion failures. Tests asserting on those messages are updated to match.

## Breaking change

Failure and exception message text changes. Tests asserting on exact message strings may need updating. `expectExceptionMessage()` matches substrings, so assertions that do not include the final character are unaffected, which is why only two test files needed changes here.

## Test plan

- [x] `composer test` green: 469 tests
- [x] `composer lint` green: PHPCS, PHPStan level 9, Rector
- [x] Checked for exact-match assertions on message text before changing anything; the only one found already expected a trailing period

## Before / After

```
┌─ BEFORE ─────────────────────────────────────────────────────┐
│  'Process is not initialized'                                │
│  'Class %s does not exist'                                   │
│  'All prefix arguments must be unique'                       │
│  'Loader must return an instance of Application'             │
│                                                              │
│  'Command cannot be empty.'                                  │
│  'Minimum width must be a positive integer.'                 │
│                                                              │
│  roughly 10 with, 10 without, sometimes in one trait         │
└──────────────────────────────────────────────────────────────┘
                               │
                               ▼
┌─ AFTER ──────────────────────────────────────────────────────┐
│  'Process is not initialized.'                               │
│  'Class %s does not exist.'                                  │
│  'All prefix arguments must be unique.'                      │
│  'Loader must return an instance of Application.'            │
│                                                              │
│  'Command cannot be empty.'                                  │
│  'Minimum width must be a positive integer.'                 │
│                                                              │
│  one spelling everywhere                                     │
└──────────────────────────────────────────────────────────────┘
```
