### PR TITLE
Fixed 'applicationRun()' swallowing its own expected-failure assertion.

### DIFF
--- a/src/Traits/ApplicationTrait.php
+++ b/src/Traits/ApplicationTrait.php
@@ -209,6 +209,7 @@ trait ApplicationTrait {
     $options += ['capture_stderr_separately' => TRUE];
 
     $output = '';
+    $succeeded_unexpectedly = FALSE;
     try {
       $this->applicationTester->run($input, $options);
       $output = $this->applicationTester->getDisplay();
@@ -219,14 +220,18 @@ trait ApplicationTrait {
         // @codeCoverageIgnoreEnd
       }
 
-      // Expected to succeed, but failed.
       if ($this->applicationTester->getStatusCode() !== 0) {
-        throw new \Exception(sprintf("Application exited with non-zero code.\nThe output was:\n%s\nThe error output was:\n%s", $this->applicationTester->getDisplay(), $this->applicationTester->getErrorOutput()));
+        // An expected failure keeps the application output; only an unexpected
+        // one is converted into a diagnostic by the catch blocks below.
+        if (!$expect_fail) {
+          throw new \Exception(sprintf("Application exited with non-zero code.\nThe output was:\n%s\nThe error output was:\n%s", $this->applicationTester->getDisplay(), $this->applicationTester->getErrorOutput()));
+        }
       }
-
-      // Expected to fail, but succeeded.
-      if ($expect_fail) {
-        throw new AssertionFailedError(sprintf("Application exited successfully but should not.\nThe output was:\n%s\nThe error output was:\n%s", $this->applicationTester->getDisplay(), $this->applicationTester->getErrorOutput()));
+      // AssertionFailedError descends from \RuntimeException, so throwing it
+      // here would be caught below. Record the outcome and throw after the
+      // catch blocks instead.
+      elseif ($expect_fail) {
+        $succeeded_unexpectedly = TRUE;
       }
     }
     catch (\RuntimeException $exception) {
@@ -244,6 +249,10 @@ trait ApplicationTrait {
       }
       // Expected to fail, so capture the output.
       $output = $exception->getMessage();
+    }
+
+    if ($succeeded_unexpectedly) {
+      throw new AssertionFailedError(sprintf("Application exited successfully but should not.\nThe output was:\n%s\nThe error output was:\n%s", $this->applicationTester->getDisplay(), $this->applicationTester->getErrorOutput()));
     }
 
     // Error output is captured separately, so append it to the output.

--- a/tests/Unit/ApplicationTraitTest.php
+++ b/tests/Unit/ApplicationTraitTest.php
@@ -181,6 +181,38 @@ final class ApplicationTraitTest extends UnitTestCase {
     $this->assertApplicationOutputContains('Hello, TestUser!');
   }
 
+  public function testApplicationRunExpectedFailureReturnsOutput(): void {
+    $command = new class() extends Command {
+
+      protected function configure(): void {
+        $this->setName('test:exit-code');
+      }
+
+      protected function execute(InputInterface $input, OutputInterface $output): int {
+        $output->writeln('Important output line');
+
+        return Command::FAILURE;
+      }
+
+    };
+
+    $this->applicationInitFromCommand($command);
+
+    $output = $this->applicationRun([], [], TRUE);
+
+    $this->assertStringContainsString('Important output line', $output);
+    $this->assertStringNotContainsString('Application exited with non-zero code', $output);
+  }
+
+  public function testApplicationRunExpectedFailureButSucceeded(): void {
+    $this->applicationInitFromCommand(GreetingCommand::class);
+
+    $this->expectException(AssertionFailedError::class);
+    $this->expectExceptionMessage('Application exited successfully but should not.');
+
+    $this->applicationRun([], [], TRUE);
+  }
+
   public function testApplicationRunExceptionHandling(): void {
     $this->application = new Application();
 


### PR DESCRIPTION
## Summary

`applicationRun()` had an expectation path that could never fail a test. When the application succeeded but `$expect_fail` was `TRUE`, the `AssertionFailedError` thrown to signal that was immediately swallowed by the method's own `catch (\RuntimeException)`, because `AssertionFailedError` extends `PHPUnit\Framework\Exception`, which extends `RuntimeException`.

The caught exception was then converted into the return value, so the method handed back its own failure message as if it were application output. A test asserting on that output would silently assert against error text.

Separately, when the application exited non-zero and a failure *was* expected, the diagnostic string replaced the real output and stderr was appended a second time on top of the copy already embedded in that diagnostic.

## Changes

- The "succeeded but a failure was expected" outcome is recorded in a flag inside the `try`, then thrown after the `catch` blocks where nothing can intercept it.
- A non-zero exit only raises the diagnostic exception when the failure was *not* expected. An expected failure keeps the application output intact and stderr is appended exactly once.

## Test plan

- [x] `composer test` green: 458 tests
- [x] `composer lint` green: PHPCS, PHPStan level 9, Rector
- [x] Both paths reproduced before the fix and verified after
- [x] `testApplicationRunExpectedFailureButSucceeded` asserts the failure now raises
- [x] `testApplicationRunExpectedFailureReturnsOutput` asserts the returned string contains the command output and not the diagnostic

## Before / After

```
┌─ BEFORE ─────────────────────────────────────────────────────┐
│  app succeeds, $expect_fail = TRUE                           │
│    throw AssertionFailedError                                │
│      └─ caught by own catch (\RuntimeException)              │
│         └─ returned as output; test PASSES                   │
│                                                              │
│  app exits non-zero, $expect_fail = TRUE                     │
│    output replaced by diagnostic, stderr duplicated          │
└──────────────────────────────────────────────────────────────┘
                               │
                               ▼
┌─ AFTER ──────────────────────────────────────────────────────┐
│  app succeeds, $expect_fail = TRUE                           │
│    flag set, thrown after the catch blocks                   │
│      └─ nothing intercepts it; test FAILS                    │
│                                                              │
│  app exits non-zero, $expect_fail = TRUE                     │
│    application output preserved, stderr appended once        │
└──────────────────────────────────────────────────────────────┘
```
