### PR TITLE
Inserted explicit arguments before the end-of-options marker.

### DIFF
--- a/src/Traits/ProcessTrait.php
+++ b/src/Traits/ProcessTrait.php
@@ -104,7 +104,9 @@ trait ProcessTrait {
    *   The command to run. Can be a single command or command with arguments
    *   separated by spaces (e.g., "git status" or "ls -la").
    * @param array $arguments
-   *   Additional command arguments.
+   *   Additional command arguments. When the command string contains an
+   *   end-of-options marker (--), these are inserted before it so they keep
+   *   their option meaning.
    *   Note: All scalar arguments are converted to strings (TRUE→"1", FALSE→"").
    * @param array $inputs
    *   Array of inputs for interactive processes.
@@ -133,11 +135,29 @@ trait ProcessTrait {
     $base_command = array_shift($parsed_command);
     $parsed_arguments = $parsed_command;
 
+    // @codeCoverageIgnoreStart
+    if ($base_command === NULL) {
+      throw new \InvalidArgumentException('Command cannot be empty.');
+    }
+    // @codeCoverageIgnoreEnd
     if (preg_match('/[^a-zA-Z0-9_\-.\/]/', $base_command)) {
       throw new \InvalidArgumentException(sprintf('Invalid command: %s. Only alphanumeric characters, dots, dashes, underscores and slashes are allowed.', $base_command));
     }
 
-    $all_arguments = array_values(array_merge($parsed_arguments, $arguments));
+    // Everything after the end-of-options marker is positional, so appending
+    // there would strip the option meaning from caller-supplied arguments.
+    $marker_position = array_search('--', $parsed_arguments, TRUE);
+    if ($marker_position === FALSE) {
+      $all_arguments = array_merge($parsed_arguments, $arguments);
+    }
+    else {
+      $all_arguments = array_merge(
+        array_slice($parsed_arguments, 0, $marker_position),
+        $arguments,
+        array_slice($parsed_arguments, $marker_position)
+      );
+    }
+    $all_arguments = array_values($all_arguments);
 
     foreach ($all_arguments as &$arg) {
       if (!is_scalar($arg)) {
@@ -192,9 +212,10 @@ trait ProcessTrait {
    * Parses a command string into command and arguments.
    *
    * Handles quoted arguments and escaping properly. Supports both single
-   * and double quotes. Also supports the end-of-options marker (--) which
-   * stops option parsing and treats all subsequent tokens as positional
-   * arguments.
+   * and double quotes. The end-of-options marker (--) is emitted as an
+   * ordinary token: the parser draws no option/positional distinction, and
+   * the target program interprets the marker. processRun() places
+   * caller-supplied arguments before it.
    *
    * The parser deliberately allows backslash escaping inside single quotes
    * (e.g., 'It\'s working'). POSIX shells treat backslashes inside single
@@ -204,7 +225,7 @@ trait ProcessTrait {
    * @param string $command
    *   The command string to parse.
    *
-   * @return array
+   * @return list<string>
    *   Array with command as first element and arguments as subsequent elements.
    *
    * @throws \InvalidArgumentException
@@ -223,7 +244,6 @@ trait ProcessTrait {
     $escaped = FALSE;
     $length = strlen($command);
     $has_content = FALSE;
-    $end_of_options_found = FALSE;
 
     for ($i = 0; $i < $length; $i++) {
       $char = $command[$i];
@@ -255,15 +275,6 @@ trait ProcessTrait {
 
       if (!$in_quotes && ($char === ' ' || $char === "\t")) {
         if ($current !== '' || $has_content) {
-          if (!$end_of_options_found && $current === '--') {
-            $end_of_options_found = TRUE;
-            // Keep the -- marker so the command receives it.
-            $parts[] = $current;
-            $current = '';
-            $has_content = FALSE;
-            continue;
-          }
-
           $parts[] = $current;
           $current = '';
           $has_content = FALSE;

--- a/tests/Fixtures/argv-echo.sh
+++ b/tests/Fixtures/argv-echo.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+##
+# Prints every received argument on its own line, prefixed by its position.
+#
+# @usage: ./argv-echo.sh --flag -- positional
+
+set -e
+
+position=0
+for arg in "$@"; do
+  position=$((position + 1))
+  echo "ARGV[${position}]=${arg}"
+done

--- a/tests/Functional/ProcessTraitArgumentsTest.php
+++ b/tests/Functional/ProcessTraitArgumentsTest.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AlexSkrypnyk\PhpunitHelpers\Tests\Functional;
+
+use AlexSkrypnyk\PhpunitHelpers\Traits\ProcessTrait;
+use AlexSkrypnyk\PhpunitHelpers\UnitTestCase;
+use PHPUnit\Framework\Attributes\CoversTrait;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+/**
+ * Asserts argument placement by inspecting a real subprocess argv.
+ */
+#[CoversTrait(ProcessTrait::class)]
+final class ProcessTraitArgumentsTest extends UnitTestCase {
+
+  use ProcessTrait;
+
+  protected function setUp(): void {
+    parent::setUp();
+    $this->processStreamOutput = FALSE;
+  }
+
+  protected function tearDown(): void {
+    $this->processTearDown();
+    parent::tearDown();
+  }
+
+  #[DataProvider('dataProviderArgumentPlacement')]
+  public function testArgumentPlacement(string $suffix, array $arguments, array $expected): void {
+    if (DIRECTORY_SEPARATOR === '\\') {
+      $this->markTestSkipped('Requires POSIX utilities');
+    }
+
+    if (!self::$fixtures) {
+      throw new \RuntimeException('Fixtures directory is not set.');
+    }
+
+    $this->processRun(self::$fixtures . '/argv-echo.sh' . $suffix, $arguments);
+
+    $this->assertProcessSuccessful();
+    $this->assertProcessOutputContains($expected);
+
+    $output = $this->processGet()->getOutput();
+    $this->assertSame(count($expected), substr_count($output, 'ARGV['), 'Subprocess received exactly the expected number of arguments.');
+  }
+
+  public static function dataProviderArgumentPlacement(): \Iterator {
+    yield 'no_marker_arguments_appended' => [
+      ' --flag',
+      ['extra'],
+      ['ARGV[1]=--flag', 'ARGV[2]=extra'],
+    ];
+    yield 'marker_arguments_inserted_before_it' => [
+      ' -- positional',
+      ['--flag'],
+      ['ARGV[1]=--flag', 'ARGV[2]=--', 'ARGV[3]=positional'],
+    ];
+    yield 'marker_first_token_arguments_lead' => [
+      ' -- -abc',
+      ['--extra'],
+      ['ARGV[1]=--extra', 'ARGV[2]=--', 'ARGV[3]=-abc'],
+    ];
+    yield 'marker_with_options_before_it' => [
+      ' -v -- --dry-run',
+      ['--extra'],
+      ['ARGV[1]=-v', 'ARGV[2]=--extra', 'ARGV[3]=--', 'ARGV[4]=--dry-run'],
+    ];
+    yield 'only_first_marker_is_the_boundary' => [
+      ' -- first -- second',
+      ['--extra'],
+      ['ARGV[1]=--extra', 'ARGV[2]=--', 'ARGV[3]=first', 'ARGV[4]=--', 'ARGV[5]=second'],
+    ];
+    yield 'marker_without_arguments_passes_through' => [
+      ' -- positional',
+      [],
+      ['ARGV[1]=--', 'ARGV[2]=positional'],
+    ];
+    yield 'quoted_marker_is_not_a_boundary' => [
+      ' "-- quoted" tail',
+      ['--extra'],
+      ['ARGV[1]=-- quoted', 'ARGV[2]=tail', 'ARGV[3]=--extra'],
+    ];
+  }
+
+}

--- a/tests/Unit/ProcessTraitTest.php
+++ b/tests/Unit/ProcessTraitTest.php
@@ -912,8 +912,7 @@ EOL;
   }
 
   public function testProcessRunExplicitArgumentsPrecedence(): void {
-    // Explicit arguments are appended after parsed ones to preserve command
-    // structure, especially -- markers.
+    // Without an end-of-options marker, explicit arguments are appended.
     $this->processRun('echo default-arg1 default-arg2', ['override-arg1', 'override-arg2']);
 
     $this->assertProcessSuccessful();
@@ -924,7 +923,7 @@ EOL;
     $this->processRun('echo command -- after-marker', ['explicit']);
 
     $this->assertProcessSuccessful();
-    $this->assertProcessOutputContains('command -- after-marker explicit');
+    $this->assertProcessOutputContains('command explicit -- after-marker');
   }
 
   public function testProcessRunWithIdleTimeout(): void {


### PR DESCRIPTION
> Stacked on #102. Review that one first; this PR's diff is only its own change.

## Summary

`processParseCommand()` documented that the `--` end-of-options marker "stops option parsing and treats all subsequent tokens as positional arguments". It did not. Both branches of the `if` performed the same three statements, and the only difference was setting `$end_of_options_found`, a flag read nowhere except the condition that set it. Tokenisation was byte-identical with the branch deleted.

Real semantics now live where the marker can actually matter. Parsed tokens are handed to `new Process([...])` as an argv array, so no shell is involved and the *target program* interprets `--`. The one place position mattered was `processRun()`, which appended the `$arguments` parameter after any `--` from the command string, silently turning caller-supplied options into positionals.

## Changes

- `processRun()` inserts `$arguments` before the first `--` from the parsed command, so they keep their option meaning. Without a marker, they are appended as before.
- The inert branch and its flag are removed from the parser.
- The parser docblock now states what it actually does: `--` is emitted as an ordinary token and interpreted by the target program.
- `processParseCommand()` is typed `@return list<string>`, with a guard for the empty case that PHPStan cannot otherwise rule out.
- New `argv-echo.sh` fixture prints each received argument with its position, and `ProcessTraitArgumentsTest` asserts placement against a real subprocess argv.

## Breaking change

When the command string contains `--`, arguments passed via `$arguments` now land before the marker rather than after it.

```php
$this->processRun('command -- after-marker', ['explicit']);

// before: command -- after-marker explicit
// after:  command explicit -- after-marker
```

This reverses a previously intentional, tested behaviour. `testProcessRunWithEndOfOptionsAndExplicitArgs` asserted the old order, and a comment stated explicit arguments were appended "to preserve command structure, especially `--` markers". Both are updated here.

## Test plan

- [x] `composer test` green: 465 tests
- [x] `composer lint` green: PHPCS, PHPStan level 9, Rector
- [x] 7 functional tests inspect a real subprocess argv
- [x] Verified 4 of those 7 fail when the change is reverted, so they pin the behaviour rather than pass vacuously

## Before / After

```
┌─ BEFORE ─────────────────────────────────────────────────────┐
│  parser    if (!$found && $current === '--') { ... }         │
│              both branches identical; flag never read        │
│              tokenisation unchanged either way               │
│                                                              │
│  processRun('run -- -abc', ['--extra'])                      │
│    argv:   run  --  -abc  --extra                            │
│                          └─ option became positional         │
└──────────────────────────────────────────────────────────────┘
                               │
                               ▼
┌─ AFTER ──────────────────────────────────────────────────────┐
│  parser    branch and flag removed; docblock states that     │
│            -- is a plain token for the target program        │
│                                                              │
│  processRun('run -- -abc', ['--extra'])                      │
│    argv:   run  --extra  --  -abc                            │
│                 └─ stays an option                           │
└──────────────────────────────────────────────────────────────┘
```
