### PR TITLE
Split path exceptions by cause and fixed the empty path in the message.

### DIFF
--- a/src/Traits/LocationsTrait.php
+++ b/src/Traits/LocationsTrait.php
@@ -284,13 +284,13 @@ trait LocationsTrait {
    * @return array<int, string>
    *   The list of created file paths.
    *
-   * @throws \RuntimeException
-   *   When the base directory does not exist.
+   * @throws \InvalidArgumentException
+   *   When the base path is not a directory.
    */
   public static function locationsCopyFilesToSut(array $files, ?string $basedir = NULL, bool $append_rand = TRUE): array {
     $basedir = $basedir ?: getcwd();
     if (!$basedir || !is_dir($basedir)) {
-      throw new \RuntimeException(sprintf('The base directory "%s" does not exist.', $basedir));
+      throw new \InvalidArgumentException(sprintf('The base path "%s" is not a directory.', $basedir));
     }
     return static::locationsCopy($basedir, static::$sut, $files, [], function (string &$src, string &$dst) use ($append_rand): void {
       $dst .= ($append_rand ? random_int(1000, 9999) : '');
@@ -323,18 +323,18 @@ trait LocationsTrait {
    * @return string
    *   The real path.
    *
-   * @throws \RuntimeException
+   * @throws \InvalidArgumentException
    *   If the path does not exist.
    */
   public static function locationsRealpath(string $path): string {
-    $path = realpath($path);
+    $resolved = realpath($path);
 
     // @codeCoverageIgnoreStart
-    if ($path === FALSE) {
-      throw new \RuntimeException(sprintf('Path "%s" does not exist.', $path));
+    if ($resolved === FALSE) {
+      throw new \InvalidArgumentException(sprintf('Path "%s" does not exist.', $path));
     }
     // @codeCoverageIgnoreEnd
-    return $path;
+    return $resolved;
   }
 
   /**

--- a/tests/Unit/LocationsTraitTest.php
+++ b/tests/Unit/LocationsTraitTest.php
@@ -227,6 +227,33 @@ class LocationsTraitTest extends TestCase {
     }
   }
 
+  #[DataProvider('dataProviderLocationsCopyFilesToSutInvalidBasedir')]
+  public function testLocationsCopyFilesToSutInvalidBasedir(string $type): void {
+    $this->locationsInit($this->testCwd);
+
+    $basedir = $this->testTmp . DIRECTORY_SEPARATOR . 'not_a_directory';
+    if ($type === 'file') {
+      file_put_contents($basedir, 'This is a file, not a directory.');
+    }
+
+    $this->expectException(\InvalidArgumentException::class);
+    $this->expectExceptionMessage('is not a directory.');
+
+    try {
+      self::locationsCopyFilesToSut([], $basedir);
+    }
+    finally {
+      if (is_file($basedir)) {
+        unlink($basedir);
+      }
+    }
+  }
+
+  public static function dataProviderLocationsCopyFilesToSutInvalidBasedir(): \Iterator {
+    yield 'missing_path' => ['missing'];
+    yield 'existing_file' => ['file'];
+  }
+
   public function testLocationsTearDown(): void {
     self::$workspace = $this->testTmp . DIRECTORY_SEPARATOR . 'test_workspace_' . uniqid();
     mkdir(self::$workspace, 0777, TRUE);


### PR DESCRIPTION
## Summary

`LocationsTrait` raised `RuntimeException` for a bad path the caller supplied, while `LoggerTrait::logFile()` raised `InvalidArgumentException` for the same kind of mistake. Neither was wrong on its own, but there was no rule, so the two coexisted with no way to predict which a method would use.

The rule applied here: bad caller input raises `\InvalidArgumentException`; an environment that is not as the trait expected raises `\RuntimeException`.

## Changes

| Method | Before | After | Why |
|---|---|---|---|
| `locationsCopyFilesToSut($basedir)` | `RuntimeException` | `InvalidArgumentException` | The caller supplied the path |
| `locationsRealpath($path)` | `RuntimeException` | `InvalidArgumentException` | The caller supplied the path |
| `locationsFixtureDir()` | `RuntimeException` | unchanged | The trait's own expectation about the project layout |
| `logFile($path)` | `InvalidArgumentException` | unchanged | The caller supplied the path |

Two message defects fixed alongside:

- `locationsRealpath()` built its error message from `$path` after `realpath()` had already overwritten it with `FALSE`, so the message always printed an empty path. The resolved value now uses a separate variable and the message reports the path that actually failed.
- `locationsCopyFilesToSut()` said the base directory "does not exist", but the guard is `!is_dir(...)`, which also rejects an existing regular file. It now reads "is not a directory", and the `@throws` description matches.

## Breaking change

Consumers catching `RuntimeException` around `locationsCopyFilesToSut()` or `locationsRealpath()` need to catch `InvalidArgumentException` instead.

## Coverage

The `!is_dir($basedir)` guard had no test, so the changed `throw` line was uncovered. `testLocationsCopyFilesToSutInvalidBasedir` now covers it with two datasets: a path that does not exist, and an existing regular file. The second is the case the old "does not exist" wording described wrongly.

The other changed lines in `locationsRealpath()` are exercised by existing tests; its `throw` sits inside an existing `@codeCoverageIgnore` block.

## Test plan

- [x] `composer test` green: 467 tests
- [x] `composer lint` green: PHPCS, PHPStan level 9, Rector
- [x] Confirmed against the Cobertura report that all three changed executable lines are hit

## Before / After

```
┌─ BEFORE ─────────────────────────────────────────────────────┐
│  logFile(bad path)              InvalidArgumentException     │
│  locationsRealpath(bad path)    RuntimeException             │
│  locationsCopyFilesToSut(...)   RuntimeException             │
│  locationsFixtureDir()          RuntimeException             │
│    no rule; same mistake, two classes                        │
│                                                              │
│  realpath error message printed an empty path                │
│  "does not exist" also raised for an existing file           │
└──────────────────────────────────────────────────────────────┘
                               │
                               ▼
┌─ AFTER ──────────────────────────────────────────────────────┐
│  caller passed a bad value   -> InvalidArgumentException     │
│    logFile, locationsRealpath, locationsCopyFilesToSut       │
│                                                              │
│  environment not as expected -> RuntimeException             │
│    locationsFixtureDir                                       │
│                                                              │
│  messages report the path that failed, and say               │
│  "is not a directory" where that is what was checked         │
└──────────────────────────────────────────────────────────────┘
```


