### PR TITLE
Converged naming, API shape and source comments across the codebase.

### DIFF
--- a/src/Traits/ApplicationTrait.php
+++ b/src/Traits/ApplicationTrait.php
@@ -221,32 +221,22 @@ trait ApplicationTrait {
 
       if ($this->applicationTester->getStatusCode() !== 0) {
         // An expected failure keeps the application output; only an unexpected
-        // one is converted into a diagnostic by the catch blocks below.
+        // one is converted into a diagnostic by the catch block below.
         if (!$expect_fail) {
           throw new \Exception(sprintf("Application exited with non-zero code.\nThe output was:\n%s\nThe error output was:\n%s", $this->applicationTester->getDisplay(), $this->applicationTester->getErrorOutput()));
         }
       }
       // AssertionFailedError descends from \RuntimeException, so throwing it
       // here would be caught below. Record the outcome and throw after the
-      // catch blocks instead.
+      // catch block instead.
       elseif ($expect_fail) {
         $succeeded_unexpectedly = TRUE;
       }
     }
-    catch (\RuntimeException $exception) {
-      // Expected to succeed, but failed.
-      if (!$expect_fail) {
-        throw new AssertionFailedError('Application exited with an error:' . PHP_EOL . $exception->getMessage(), $exception->getCode(), $exception);
-      }
-      // Expected to fail, so capture the output.
-      $output = $exception->getMessage();
-    }
     catch (\Exception $exception) {
       if (!$expect_fail) {
-        // Expected to succeed, but failed.
         throw new AssertionFailedError('Application exited with an error:' . PHP_EOL . $exception->getMessage(), $exception->getCode(), $exception);
       }
-      // Expected to fail, so capture the output.
       $output = $exception->getMessage();
     }
 

--- a/src/Traits/ApplicationTrait.php
+++ b/src/Traits/ApplicationTrait.php
@@ -500,7 +500,8 @@ trait ApplicationTrait {
    */
   public function assertApplicationAnyOutputContains(array|string $expected, ?string $message = NULL): void {
     $this->assertNotNull($this->applicationTester, $message ?: 'Application is not initialized.');
-    $output = $this->applicationTester->getDisplay() . $this->applicationTester->getErrorOutput();
+    $output = $this->applicationTester->getDisplay();
+    $output .= $this->applicationTester->getErrorOutput();
 
     $expected = is_array($expected) ? $expected : [$expected];
 
@@ -527,7 +528,8 @@ trait ApplicationTrait {
    */
   public function assertApplicationAnyOutputNotContains(array|string $expected, ?string $message = NULL): void {
     $this->assertNotNull($this->applicationTester, $message ?: 'Application is not initialized.');
-    $output = $this->applicationTester->getDisplay() . $this->applicationTester->getErrorOutput();
+    $output = $this->applicationTester->getDisplay();
+    $output .= $this->applicationTester->getErrorOutput();
 
     $expected = is_array($expected) ? $expected : [$expected];
 

--- a/src/Traits/LoggerTrait.php
+++ b/src/Traits/LoggerTrait.php
@@ -317,12 +317,12 @@ trait LoggerTrait {
       return strlen($indentation . $step['name']);
     }, static::$logSteps);
     $max_name_length = max($name_lengths);
-    // Minimum for "Step" header.
+    // The "Step" header sets the minimum.
     $max_name_length = max($max_name_length, 4);
 
-    // "Complete" or "Running"
+    // The status is "Complete" or "Running".
     $max_status_length = 8;
-    // "Elapsed" header length
+    // The "Elapsed" header is 7 characters.
     $max_elapsed_length = 7;
 
     $header = sprintf(

--- a/src/Traits/LoggerTrait.php
+++ b/src/Traits/LoggerTrait.php
@@ -81,7 +81,7 @@ trait LoggerTrait {
    *   The output stream resource (STDERR if not set).
    */
   protected static function logGetOutputStream() {
-    return static::$logOutputStream ?: STDERR;
+    return static::$logOutputStream ?? STDERR;
   }
 
   /**

--- a/src/Traits/ProcessTrait.php
+++ b/src/Traits/ProcessTrait.php
@@ -214,8 +214,7 @@ trait ProcessTrait {
    * Handles quoted arguments and escaping properly. Supports both single
    * and double quotes. The end-of-options marker (--) is emitted as an
    * ordinary token: the parser draws no option/positional distinction, and
-   * the target program interprets the marker. processRun() places
-   * caller-supplied arguments before it.
+   * the target program interprets the marker.
    *
    * The parser deliberately allows backslash escaping inside single quotes
    * (e.g., 'It\'s working'). POSIX shells treat backslashes inside single

--- a/src/Traits/ProcessTrait.php
+++ b/src/Traits/ProcessTrait.php
@@ -444,12 +444,12 @@ trait ProcessTrait {
     foreach ($expected as $value) {
       if (is_string($value)) {
         $this->assertStringContainsString($value, $output, $message ?: sprintf(
-            "Process output does not contain '%s'.%sOutput:%s%s",
-            $value,
-            PHP_EOL,
-            PHP_EOL,
-            $output
-          ) . $this->assertionSuffix());
+          "Process output does not contain '%s'.%sOutput:%s%s",
+          $value,
+          PHP_EOL,
+          PHP_EOL,
+          $output
+        ) . $this->assertionSuffix());
       }
     }
   }
@@ -471,12 +471,12 @@ trait ProcessTrait {
     foreach ($expected as $value) {
       if (is_string($value)) {
         $this->assertStringNotContainsString($value, $output, $message ?: sprintf(
-            "Process output contains '%s' but should not.%sOutput:%s%s",
-            $value,
-            PHP_EOL,
-            PHP_EOL,
-            $output
-          ) . $this->assertionSuffix());
+          "Process output contains '%s' but should not.%sOutput:%s%s",
+          $value,
+          PHP_EOL,
+          PHP_EOL,
+          $output
+        ) . $this->assertionSuffix());
       }
     }
   }
@@ -498,12 +498,12 @@ trait ProcessTrait {
     foreach ($expected as $value) {
       if (is_string($value)) {
         $this->assertStringContainsString($value, $output, $message ?: sprintf(
-            "Process error output does not contain '%s'.%sOutput:%s%s",
-            $value,
-            PHP_EOL,
-            PHP_EOL,
-            $output
-          ) . $this->assertionSuffix());
+          "Process error output does not contain '%s'.%sOutput:%s%s",
+          $value,
+          PHP_EOL,
+          PHP_EOL,
+          $output
+        ) . $this->assertionSuffix());
       }
     }
   }
@@ -525,12 +525,12 @@ trait ProcessTrait {
     foreach ($expected as $value) {
       if (is_string($value)) {
         $this->assertStringNotContainsString($value, $output, $message ?: sprintf(
-            "Process error output contains '%s' but should not.%sOutput:%s%s",
-            $value,
-            PHP_EOL,
-            PHP_EOL,
-            $output
-          ) . $this->assertionSuffix());
+          "Process error output contains '%s' but should not.%sOutput:%s%s",
+          $value,
+          PHP_EOL,
+          PHP_EOL,
+          $output
+        ) . $this->assertionSuffix());
       }
     }
   }
@@ -642,12 +642,12 @@ trait ProcessTrait {
     foreach ($expected as $value) {
       if (is_string($value)) {
         $this->assertStringContainsString($value, $output, $message ?: sprintf(
-            "Process output does not contain '%s'.%sOutput:%s%s",
-            $value,
-            PHP_EOL,
-            PHP_EOL,
-            $output
-          ) . $this->assertionSuffix());
+          "Process output does not contain '%s'.%sOutput:%s%s",
+          $value,
+          PHP_EOL,
+          PHP_EOL,
+          $output
+        ) . $this->assertionSuffix());
       }
     }
   }
@@ -673,12 +673,12 @@ trait ProcessTrait {
     foreach ($expected as $value) {
       if (is_string($value)) {
         $this->assertStringNotContainsString($value, $output, $message ?: sprintf(
-            "Process output contains '%s' but should not.%sOutput:%s%s",
-            $value,
-            PHP_EOL,
-            PHP_EOL,
-            $output
-          ) . $this->assertionSuffix());
+          "Process output contains '%s' but should not.%sOutput:%s%s",
+          $value,
+          PHP_EOL,
+          PHP_EOL,
+          $output
+        ) . $this->assertionSuffix());
       }
     }
   }

--- a/src/Traits/StringTrait.php
+++ b/src/Traits/StringTrait.php
@@ -14,7 +14,7 @@ trait StringTrait {
   /**
    * Asserts string contains or does not contain expected values with prefixes.
    *
-   * Supports four single-character prefixes for precise matching control:
+   * Supports four single-character prefixes to control matching:
    * - '+' = exact match present
    * - '*' = substring present
    * - '-' = exact match absent

--- a/src/Traits/StringTrait.php
+++ b/src/Traits/StringTrait.php
@@ -49,6 +49,8 @@ trait StringTrait {
    *   When prefix arguments are invalid (not single characters or not unique).
    * @throws \RuntimeException
    *   When prefix usage is inconsistent or values are empty after stripping.
+   * @throws \PHPUnit\Framework\AssertionFailedError
+   *   When an assertion on the haystack fails.
    */
   protected function assertStringContainsOrNot(
     string $haystack,

--- a/src/Traits/TuiTrait.php
+++ b/src/Traits/TuiTrait.php
@@ -5,10 +5,7 @@ declare(strict_types=1);
 namespace AlexSkrypnyk\PhpunitHelpers\Traits;
 
 /**
- * Trait TuiTrait.
- *
- * Provides constants and methods for interacting with a
- * Textual User Interface (TUI).
+ * Provides helpers for interacting with a Textual User Interface (TUI).
  *
  * A "keystroke" is a single key or special key.
  * An "entry" consists of one or more keystrokes that form a complete input.

--- a/tests/Fixtures/Application/Command/ErrorOutputCommand.php
+++ b/tests/Fixtures/Application/Command/ErrorOutputCommand.php
@@ -28,7 +28,7 @@ class ErrorOutputCommand extends Command {
       $error_output->writeln('Test Error');
     }
     else {
-      fwrite(STDERR, "Test Error" . PHP_EOL);
+      fwrite(STDERR, 'Test Error' . PHP_EOL);
     }
     $output->writeln('Output message');
 

--- a/tests/Fixtures/Application/Command/ExceptionOutputCommand.php
+++ b/tests/Fixtures/Application/Command/ExceptionOutputCommand.php
@@ -30,7 +30,7 @@ class ExceptionOutputCommand extends Command {
       $error_output->writeln('Error output before exception');
     }
     else {
-      fwrite(STDERR, "Error output before exception" . PHP_EOL);
+      fwrite(STDERR, 'Error output before exception' . PHP_EOL);
     }
 
     throw new \RuntimeException('Test exception message');

--- a/tests/Fixtures/StreamCaptureFilter.php
+++ b/tests/Fixtures/StreamCaptureFilter.php
@@ -20,7 +20,6 @@ class StreamCaptureFilter extends \php_user_filter {
   /**
    * {@inheritdoc}
    */
-  #[\Override]
   public function filter($in, $out, &$consumed, bool $closing): int {
     while ($bucket = stream_bucket_make_writeable($in)) {
       static::$captured .= $bucket->data;

--- a/tests/Functional/LoggerTraitFunctionalTest.php
+++ b/tests/Functional/LoggerTraitFunctionalTest.php
@@ -42,9 +42,7 @@ final class LoggerTraitFunctionalTest extends UnitTestCase {
   }
 
   /**
-   * Functional test: Demonstrate basic logging to STDERR.
-   *
-   * This test outputs to real STDERR to show what the logging looks like.
+   * Demonstrates basic logging to STDERR.
    */
   #[DoesNotPerformAssertions]
   public function testFunctionalBasicLogging(): void {
@@ -53,9 +51,7 @@ final class LoggerTraitFunctionalTest extends UnitTestCase {
   }
 
   /**
-   * Functional test: Demonstrate step workflow to STDERR.
-   *
-   * This test shows a complete step workflow with timing.
+   * Demonstrates a complete step workflow with timing to STDERR.
    */
   #[DoesNotPerformAssertions]
   public function testFunctionalStepWorkflow(): void {
@@ -76,9 +72,7 @@ final class LoggerTraitFunctionalTest extends UnitTestCase {
   }
 
   /**
-   * Functional test: Demonstrate section formatting variations.
-   *
-   * This test shows different section formatting options.
+   * Demonstrates section formatting variations.
    */
   #[DoesNotPerformAssertions]
   public function testFunctionalSectionFormatting(): void {
@@ -89,9 +83,7 @@ final class LoggerTraitFunctionalTest extends UnitTestCase {
   }
 
   /**
-   * Functional test: Demonstrate file logging to STDERR.
-   *
-   * This test shows file content logging.
+   * Demonstrates file content logging to STDERR.
    */
   #[DoesNotPerformAssertions]
   public function testFunctionalFileLogging(): void {
@@ -104,9 +96,7 @@ final class LoggerTraitFunctionalTest extends UnitTestCase {
   }
 
   /**
-   * Functional test: Demonstrate hierarchical step logging to STDERR.
-   *
-   * This test shows nested step workflows with hierarchy visualization.
+   * Demonstrates hierarchical step logging to STDERR.
    */
   #[DoesNotPerformAssertions]
   public function testFunctionalHierarchicalSteps(): void {
@@ -115,9 +105,6 @@ final class LoggerTraitFunctionalTest extends UnitTestCase {
     self::logStepSummary('DEPLOYMENT SUMMARY');
   }
 
-  /**
-   * Main deployment process step.
-   */
   protected function stepDeploymentProcess(): void {
     self::logStepStart('Starting main deployment workflow');
     self::log('Initializing deployment environment');
@@ -133,9 +120,6 @@ final class LoggerTraitFunctionalTest extends UnitTestCase {
     self::logStepFinish('Main deployment process completed');
   }
 
-  /**
-   * Database migration step.
-   */
   protected function stepDatabaseMigration(): void {
     self::logStepStart('Preparing database migration');
     self::log('Connecting to production database');
@@ -163,9 +147,6 @@ final class LoggerTraitFunctionalTest extends UnitTestCase {
     self::logStepFinish('Database migration completed');
   }
 
-  /**
-   * Application deployment step.
-   */
   protected function stepApplicationDeployment(): void {
     self::logStepStart('Deploying application to production');
     self::logSection('APPLICATION SERVER', 'Preparing production deployment', TRUE);
@@ -180,9 +161,6 @@ final class LoggerTraitFunctionalTest extends UnitTestCase {
     self::logStepFinish('Application deployment finished');
   }
 
-  /**
-   * Asset compilation step (deeply nested).
-   */
   protected function stepAssetCompilation(): void {
     self::logStepStart('Compiling and optimizing assets');
     self::log('Initializing build environment');
@@ -213,9 +191,6 @@ final class LoggerTraitFunctionalTest extends UnitTestCase {
     self::logStepFinish('Asset compilation completed');
   }
 
-  /**
-   * Health checks step.
-   */
   protected function stepHealthChecks(): void {
     self::logStepStart('Running system health checks');
     self::logSection('POST-DEPLOYMENT VERIFICATION', 'Validating system functionality');

--- a/tests/Functional/LoggerTraitFunctionalTest.php
+++ b/tests/Functional/LoggerTraitFunctionalTest.php
@@ -22,7 +22,8 @@ final class LoggerTraitFunctionalTest extends UnitTestCase {
    */
   protected function setUp(): void {
     parent::setUp();
-    self::logSetVerbose(FALSE);
+    self::logSetOutputStream(NULL);
+    self::logSetVerbose(TRUE);
 
     $reflection_class = new \ReflectionClass(self::class);
     $steps_property = $reflection_class->getProperty('logSteps');
@@ -47,9 +48,6 @@ final class LoggerTraitFunctionalTest extends UnitTestCase {
    */
   #[DoesNotPerformAssertions]
   public function testFunctionalBasicLogging(): void {
-    self::logSetOutputStream(NULL);
-    self::logSetVerbose(TRUE);
-
     self::log('This is a basic log message');
     self::logSection('TEST SECTION', 'This is a test section with content');
   }
@@ -61,9 +59,6 @@ final class LoggerTraitFunctionalTest extends UnitTestCase {
    */
   #[DoesNotPerformAssertions]
   public function testFunctionalStepWorkflow(): void {
-    self::logSetOutputStream(NULL);
-    self::logSetVerbose(TRUE);
-
     self::logStepStart('Processing data');
     self::logSubstep('Loading configuration');
     self::logNote('Using default settings');
@@ -87,9 +82,6 @@ final class LoggerTraitFunctionalTest extends UnitTestCase {
    */
   #[DoesNotPerformAssertions]
   public function testFunctionalSectionFormatting(): void {
-    self::logSetOutputStream(NULL);
-    self::logSetVerbose(TRUE);
-
     self::logSection('STANDARD SECTION', 'This is a standard section with single border');
     self::logSection('DOUBLE BORDER SECTION', 'This section uses double border characters', TRUE);
     self::logSection('WIDE SECTION', 'This section has a wider minimum width', FALSE, 90);
@@ -103,9 +95,6 @@ final class LoggerTraitFunctionalTest extends UnitTestCase {
    */
   #[DoesNotPerformAssertions]
   public function testFunctionalFileLogging(): void {
-    self::logSetOutputStream(NULL);
-    self::logSetVerbose(TRUE);
-
     $temp_file = tempnam(sys_get_temp_dir(), 'logger_functional_test');
     file_put_contents($temp_file, "Sample file content\nLine 2\nLine 3\n");
 
@@ -121,9 +110,6 @@ final class LoggerTraitFunctionalTest extends UnitTestCase {
    */
   #[DoesNotPerformAssertions]
   public function testFunctionalHierarchicalSteps(): void {
-    self::logSetOutputStream(NULL);
-    self::logSetVerbose(TRUE);
-
     $this->stepDeploymentProcess();
 
     self::logStepSummary('DEPLOYMENT SUMMARY');

--- a/tests/Functional/ProcessTraitArgumentsTest.php
+++ b/tests/Functional/ProcessTraitArgumentsTest.php
@@ -30,7 +30,7 @@ final class ProcessTraitArgumentsTest extends UnitTestCase {
   #[DataProvider('dataProviderArgumentPlacement')]
   public function testArgumentPlacement(string $suffix, array $arguments, array $expected): void {
     if (DIRECTORY_SEPARATOR === '\\') {
-      $this->markTestSkipped('Requires POSIX utilities');
+      $this->markTestSkipped('Requires POSIX utilities.');
     }
 
     if (!self::$fixtures) {

--- a/tests/Functional/ProcessTraitFunctionalTest.php
+++ b/tests/Functional/ProcessTraitFunctionalTest.php
@@ -13,7 +13,7 @@ use PHPUnit\Framework\Attributes\CoversNothing;
 #[CoversNothing]
 final class ProcessTraitFunctionalTest extends UnitTestCase {
 
-  public function testProcessTraitStreamingWithDebugEnabled(): void {
+  public function testProcessStreamingWithDebugEnabled(): void {
     $output = $this->runPhpunit(TRUE);
     $combined = $output['combined'];
 
@@ -50,7 +50,7 @@ final class ProcessTraitFunctionalTest extends UnitTestCase {
     $this->assertStreamingTiming($output['real_time_output']);
   }
 
-  public function testProcessTraitStreamingWithDebugDisabled(): void {
+  public function testProcessStreamingWithDebugDisabled(): void {
     $output = $this->runPhpunit(FALSE);
     $combined = $output['combined'];
 
@@ -100,7 +100,7 @@ final class ProcessTraitFunctionalTest extends UnitTestCase {
     $process = proc_open($command, $descriptors, $pipes);
 
     if (!is_resource($process)) {
-      $this->fail('Failed to start PHPUnit process');
+      $this->fail('Failed to start PHPUnit process.');
     }
 
     fclose($pipes[0]);

--- a/tests/Functional/ProcessTraitFunctionalTest.php
+++ b/tests/Functional/ProcessTraitFunctionalTest.php
@@ -41,7 +41,6 @@ final class ProcessTraitFunctionalTest extends UnitTestCase {
     $this->assertStringContainsString('Failed stdout', (string) $combined);
     $this->assertStringContainsString('Failed stderr', (string) $combined);
 
-    // Process output headers and footers appear.
     $this->assertStringContainsString('⬇⬇⬇ STANDARD OUTPUT ⬇⬇⬇', (string) $combined);
     $this->assertStringContainsString('⬆⬆⬆ STANDARD OUTPUT ⬆⬆⬆', (string) $combined);
     $this->assertStringContainsString('▼▼▼ ERROR OUTPUT ▼▼▼', (string) $combined);
@@ -77,7 +76,6 @@ final class ProcessTraitFunctionalTest extends UnitTestCase {
     $this->assertStringContainsString('Failed stdout', (string) $combined);
     $this->assertStringContainsString('Failed stderr', (string) $combined);
 
-    // Process output headers and footers appear.
     $this->assertStringContainsString('⬇⬇⬇ STANDARD OUTPUT ⬇⬇⬇', (string) $combined);
     $this->assertStringContainsString('⬆⬆⬆ STANDARD OUTPUT ⬆⬆⬆', (string) $combined);
     $this->assertStringContainsString('▼▼▼ ERROR OUTPUT ▼▼▼', (string) $combined);

--- a/tests/Unit/ApplicationTraitTest.php
+++ b/tests/Unit/ApplicationTraitTest.php
@@ -252,21 +252,21 @@ final class ApplicationTraitTest extends UnitTestCase {
     ];
   }
 
-  public function testApplicationRunWithoutInit(): void {
+  public function testApplicationRunWhenNotInitialized(): void {
     $this->expectException(\RuntimeException::class);
     $this->expectExceptionMessage('Application is not initialized.');
 
     $this->applicationRun([]);
   }
 
-  public function testApplicationGetNotInitialized(): void {
+  public function testApplicationGetWhenNotInitialized(): void {
     $this->expectException(\RuntimeException::class);
     $this->expectExceptionMessage('Application is not initialized. Call applicationInit* first.');
 
     $this->applicationGet();
   }
 
-  public function testApplicationGetTesterNotInitialized(): void {
+  public function testApplicationGetTesterWhenNotInitialized(): void {
     $this->expectException(\RuntimeException::class);
     $this->expectExceptionMessage('Application tester is not initialized. Call applicationInit* first.');
 
@@ -463,15 +463,15 @@ final class ApplicationTraitTest extends UnitTestCase {
     $this->assertStringContainsString('Error:', $info);
   }
 
-  public function testApplicationInfoUninitializedApplication(): void {
+  public function testApplicationInfoWhenNotInitialized(): void {
     $this->applicationTester = NULL;
     $info = $this->applicationInfo();
 
     $this->assertStringContainsString('APPLICATION: Not initialized', $info);
   }
 
-  #[DataProvider('dataProviderAssertionsWhenNull')]
-  public function testAssertionsWhenNull(string $method, array $arguments): void {
+  #[DataProvider('dataProviderApplicationAssertionsWhenNotInitialized')]
+  public function testApplicationAssertionsWhenNotInitialized(string $method, array $arguments): void {
     $this->applicationTester = NULL;
 
     $this->expectException(ExpectationFailedException::class);
@@ -485,7 +485,7 @@ final class ApplicationTraitTest extends UnitTestCase {
     $callable(...$arguments);
   }
 
-  public static function dataProviderAssertionsWhenNull(): \Iterator {
+  public static function dataProviderApplicationAssertionsWhenNotInitialized(): \Iterator {
     yield 'successful' => ['assertApplicationSuccessful', []];
     yield 'failed' => ['assertApplicationFailed', []];
     yield 'output_contains' => ['assertApplicationOutputContains', ['test']];
@@ -708,7 +708,7 @@ final class ApplicationTraitTest extends UnitTestCase {
     ]);
   }
 
-  public function testApplicationOutputExactMatchWithMultipleLines(): void {
+  public function testApplicationOutputContainsOrNotExactMatchMultiline(): void {
     $command = new class() extends Command {
 
       protected function configure(): void {

--- a/tests/Unit/ApplicationTraitTest.php
+++ b/tests/Unit/ApplicationTraitTest.php
@@ -378,9 +378,7 @@ final class ApplicationTraitTest extends UnitTestCase {
   }
 
   public function testAssertApplicationFailedWithSuccessStatus(): void {
-    $command = new GreetingCommand();
-
-    $this->applicationInitFromCommand($command);
+    $this->applicationInitFromCommand(GreetingCommand::class);
 
     $this->applicationRun([]);
 
@@ -390,7 +388,7 @@ final class ApplicationTraitTest extends UnitTestCase {
     $this->assertApplicationFailed();
   }
 
-  public function testApplicationInitFromLoaderWithCwd(): void {
+  public function testApplicationInitFromLoaderWithCustomCwd(): void {
     $original_cwd = getcwd();
 
     if ($original_cwd === FALSE) {

--- a/tests/Unit/ApplicationTraitTest.php
+++ b/tests/Unit/ApplicationTraitTest.php
@@ -216,7 +216,7 @@ final class ApplicationTraitTest extends UnitTestCase {
 
     $this->applicationTester = new ApplicationTester($this->application);
 
-    // With expect_fail as true, the exception should be caught.
+    // With expect_fail as TRUE, the exception is caught.
     $this->applicationRun([], [], TRUE);
 
     $this->expectException(AssertionFailedError::class);
@@ -349,8 +349,8 @@ final class ApplicationTraitTest extends UnitTestCase {
 
     $this->applicationInitFromCommand($command);
 
-    // The applicationRun should not throw an exception when the command returns
-    // a non-zero exit code but expect_fail is TRUE.
+    // applicationRun() does not throw when the command returns a non-zero
+    // exit code but expect_fail is TRUE.
     $output = $this->applicationRun([], [], TRUE);
 
     $this->assertStringContainsString('Non-zero exit', $output);
@@ -552,7 +552,7 @@ final class ApplicationTraitTest extends UnitTestCase {
 
     $this->assertApplicationSuccessful();
 
-    // Test shortcut mode - no prefixes, all should be present as substrings.
+    // Without prefixes, every string must be present as a substring.
     $this->assertApplicationAnyOutputContainsOrNot([
       'Hello',
       'Test',
@@ -565,12 +565,11 @@ final class ApplicationTraitTest extends UnitTestCase {
 
     $this->assertApplicationSuccessful();
 
-    // Test exact match present (trailing whitespace is trimmed)
+    // Trailing whitespace is trimmed before the exact match.
     $this->assertApplicationOutputContainsOrNot([
       '+ Hello, World!',
     ]);
 
-    // Test exact match absent.
     $this->assertApplicationOutputContainsOrNot([
       '- Not exact match',
     ]);
@@ -646,7 +645,7 @@ final class ApplicationTraitTest extends UnitTestCase {
 
     $this->assertApplicationSuccessful();
 
-    // Test shortcut mode - no prefixes, all should be present as substrings.
+    // Without prefixes, every string must be present as a substring.
     $this->assertApplicationAnyOutputContainsOrNot([
       'Test Error',
       'Output message',
@@ -677,8 +676,8 @@ final class ApplicationTraitTest extends UnitTestCase {
       '+ Hello, World!',
     ]);
 
-    // Single-quoted, so this holds a literal backslash-n rather than a newline
-    // and therefore never equals the output.
+    // The single-quoted string holds a literal backslash-n, not a newline,
+    // so it never equals the output.
     $this->assertApplicationOutputContainsOrNot([
       '- Hello, World!\nExtra',
     ]);
@@ -729,12 +728,11 @@ final class ApplicationTraitTest extends UnitTestCase {
 
     $this->assertApplicationSuccessful();
 
-    // Exact match with multi-line output (no need for trailing \n)
+    // Exact match works without a trailing \n.
     $this->assertApplicationOutputContainsOrNot([
       '+ Line 1' . "\n" . 'Line 2' . "\n" . 'Line 3',
     ]);
 
-    // Partial match still works.
     $this->assertApplicationOutputContainsOrNot([
       '* Line 2',
     ]);

--- a/tests/Unit/AssertArrayTraitTest.php
+++ b/tests/Unit/AssertArrayTraitTest.php
@@ -368,7 +368,6 @@ final class AssertArrayTraitTest extends TestCase {
       }
     }
 
-    // Use match statement for type-safe method calls.
     match ($method) {
       'assertArrayContainsArray' => $this->assertArrayContainsArray($args[0], $args[1]),
       'assertArrayNotContainsString' => $this->assertArrayNotContainsString($args[0], $args[1]),

--- a/tests/Unit/EnvTraitTest.php
+++ b/tests/Unit/EnvTraitTest.php
@@ -103,12 +103,16 @@ final class EnvTraitTest extends TestCase {
   public function testEnvUnsetPrefixWithSystemEnv(): void {
     self::envReset();
     putenv('TEST_SYS_PREFIX_VAR=test_value');
-    $this->assertTrue(self::envIsSet('TEST_SYS_PREFIX_VAR'));
+    try {
+      $this->assertTrue(self::envIsSet('TEST_SYS_PREFIX_VAR'));
 
-    self::envUnsetPrefix('TEST_SYS_PREFIX_');
+      self::envUnsetPrefix('TEST_SYS_PREFIX_');
 
-    $this->assertFalse(self::envIsSet('TEST_SYS_PREFIX_VAR'));
-    putenv('TEST_SYS_PREFIX_VAR');
+      $this->assertFalse(self::envIsSet('TEST_SYS_PREFIX_VAR'));
+    }
+    finally {
+      putenv('TEST_SYS_PREFIX_VAR');
+    }
   }
 
   public function testEnvReset(): void {

--- a/tests/Unit/LocationsTraitTest.php
+++ b/tests/Unit/LocationsTraitTest.php
@@ -61,14 +61,6 @@ class LocationsTraitTest extends TestCase {
     $this->assertNotEmpty(self::$fixtures);
     $this->assertSame(self::locationsRealpath($this->testFixtures), self::locationsRealpath(self::$fixtures ?? ''));
 
-    $after_called = FALSE;
-    $after = function () use (&$after_called): void {
-      $after_called = TRUE;
-    };
-
-    $this->locationsInit($this->testCwd, $after);
-    $this->assertTrue($after_called, 'Closure was called after initialization');
-
     $info = self::locationsInfo();
 
     $this->assertStringContainsString('Root', $info);

--- a/tests/Unit/LocationsTraitTest.php
+++ b/tests/Unit/LocationsTraitTest.php
@@ -204,7 +204,6 @@ class LocationsTraitTest extends TestCase {
 
     $this->assertCount(0, $copied_files);
 
-    // Test with explicit base directory and no random suffix.
     $copied_files = self::locationsCopyFilesToSut($files, $source_dir, FALSE);
 
     $this->assertCount(2, $copied_files);
@@ -292,7 +291,6 @@ class LocationsTraitTest extends TestCase {
       $file_paths[$relative_path] = $full_path;
     }
 
-    // Create a symlink for the symlink test case.
     if (isset($source_files['link_target.txt'])) {
       $target = $source_dir . DIRECTORY_SEPARATOR . 'link_target.txt';
       $link = $source_dir . DIRECTORY_SEPARATOR . 'symlink.txt';

--- a/tests/Unit/LoggerTraitTest.php
+++ b/tests/Unit/LoggerTraitTest.php
@@ -10,24 +10,16 @@ use PHPUnit\Framework\Attributes\CoversTrait;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\DoesNotPerformAssertions;
 
-/**
- * Tests for LoggerTrait.
- */
 #[CoversTrait(LoggerTrait::class)]
 final class LoggerTraitTest extends UnitTestCase {
 
   use LoggerTrait;
 
   /**
-   * Memory buffer for capturing log output.
-   *
    * @var resource
    */
   protected $logBuffer;
 
-  /**
-   * {@inheritdoc}
-   */
   protected function setUp(): void {
     parent::setUp();
     self::logSetVerbose(FALSE);
@@ -42,9 +34,6 @@ final class LoggerTraitTest extends UnitTestCase {
     $stack_property->setValue(NULL, []);
   }
 
-  /**
-   * {@inheritdoc}
-   */
   protected function tearDown(): void {
     if (is_resource($this->logBuffer)) {
       fclose($this->logBuffer);
@@ -55,9 +44,6 @@ final class LoggerTraitTest extends UnitTestCase {
     parent::tearDown();
   }
 
-  /**
-   * Test verbose mode setter and getter.
-   */
   public function testVerboseMode(): void {
     self::logSetVerbose(TRUE);
     self::log('Verbose message');
@@ -78,9 +64,6 @@ final class LoggerTraitTest extends UnitTestCase {
     $this->assertSame('', $silent_output);
   }
 
-  /**
-   * Test log method with verbose mode disabled.
-   */
   public function testLogSilentMode(): void {
     self::logSetVerbose(FALSE);
 
@@ -90,9 +73,6 @@ final class LoggerTraitTest extends UnitTestCase {
     $this->assertSame('', $output);
   }
 
-  /**
-   * Test log method with verbose mode enabled.
-   */
   public function testLogVerboseMode(): void {
     self::logSetVerbose(TRUE);
 
@@ -102,9 +82,6 @@ final class LoggerTraitTest extends UnitTestCase {
     $this->assertSame("\nTest message\n", $output);
   }
 
-  /**
-   * Test logSection method - with visual output for inspection.
-   */
   public function testLogSection(): void {
     self::logSetVerbose(TRUE);
 
@@ -128,9 +105,6 @@ final class LoggerTraitTest extends UnitTestCase {
     $this->assertStringContainsString('===', $output);
   }
 
-  /**
-   * Test logSection method with invalid min_width parameter.
-   */
   #[DataProvider('dataProviderLogSectionWithInvalidMinWidth')]
   public function testLogSectionWithInvalidMinWidth(int $min_width): void {
     self::logSetVerbose(TRUE);
@@ -142,19 +116,13 @@ final class LoggerTraitTest extends UnitTestCase {
   }
 
   /**
-   * Provides invalid min_width values for logSection validation.
-   *
    * @return \Iterator<string, array{int}>
-   *   Test cases: [min_width]
    */
   public static function dataProviderLogSectionWithInvalidMinWidth(): \Iterator {
     yield 'zero' => [0];
     yield 'negative' => [-10];
   }
 
-  /**
-   * Test logFile method with existing file.
-   */
   #[DoesNotPerformAssertions]
   public function testLogFileWithExistingFile(): void {
     self::logSetVerbose(TRUE);
@@ -168,9 +136,6 @@ final class LoggerTraitTest extends UnitTestCase {
     unlink($temp_file);
   }
 
-  /**
-   * Test logFile method with unreadable file.
-   */
   public function testLogFileWithUnreadableFile(): void {
     self::logSetVerbose(TRUE);
 
@@ -191,9 +156,6 @@ final class LoggerTraitTest extends UnitTestCase {
     }
   }
 
-  /**
-   * Test logFile method with non-existent file.
-   */
   public function testLogFileWithNonExistentFile(): void {
     self::logSetVerbose(TRUE);
 
@@ -203,9 +165,6 @@ final class LoggerTraitTest extends UnitTestCase {
     self::logFile('/non/existent/file');
   }
 
-  /**
-   * Test logFile method when verbose mode is disabled.
-   */
   #[DoesNotPerformAssertions]
   public function testLogFileSilentMode(): void {
     self::logSetVerbose(FALSE);
@@ -218,9 +177,6 @@ final class LoggerTraitTest extends UnitTestCase {
     unlink($temp_file);
   }
 
-  /**
-   * Test logSection method when verbose mode is disabled.
-   */
   #[DoesNotPerformAssertions]
   public function testLogSectionSilentMode(): void {
     self::logSetVerbose(FALSE);
@@ -228,9 +184,6 @@ final class LoggerTraitTest extends UnitTestCase {
     self::logSection('TEST TITLE', 'Test message');
   }
 
-  /**
-   * Test that methods are silent when verbose mode is disabled.
-   */
   #[DoesNotPerformAssertions]
   public function testSilentModeForAllMethods(): void {
     self::logSetVerbose(FALSE);
@@ -244,9 +197,6 @@ final class LoggerTraitTest extends UnitTestCase {
     unlink($temp_file);
   }
 
-  /**
-   * Test verbose mode persistence across method calls.
-   */
   #[DoesNotPerformAssertions]
   public function testVerboseModePersistence(): void {
     self::logSetVerbose(TRUE);
@@ -258,9 +208,6 @@ final class LoggerTraitTest extends UnitTestCase {
     self::log('Message 2');
   }
 
-  /**
-   * Test logStepStart method with verbose mode enabled.
-   */
   public function testLogStepStartVerboseMode(): void {
     self::logSetVerbose(TRUE);
 
@@ -271,9 +218,6 @@ final class LoggerTraitTest extends UnitTestCase {
     $this->assertStringContainsString('---', $output);
   }
 
-  /**
-   * Test logStepStart method with custom step method prefix.
-   */
   public function testLogStepStartWithCustomPrefix(): void {
     self::logSetVerbose(TRUE);
 
@@ -291,9 +235,6 @@ final class LoggerTraitTest extends UnitTestCase {
     }
   }
 
-  /**
-   * Test logStepStart method with verbose mode disabled.
-   */
   #[DoesNotPerformAssertions]
   public function testLogStepStartSilentMode(): void {
     self::logSetVerbose(FALSE);
@@ -302,9 +243,6 @@ final class LoggerTraitTest extends UnitTestCase {
     self::logStepStart('Silent step start');
   }
 
-  /**
-   * Test logStepFinish method with verbose mode enabled.
-   */
   public function testLogStepFinishVerboseMode(): void {
     self::logSetVerbose(TRUE);
 
@@ -317,9 +255,6 @@ final class LoggerTraitTest extends UnitTestCase {
     $this->assertStringContainsString('Completed the test step', $output);
   }
 
-  /**
-   * Test logStepFinish method with custom step method prefix.
-   */
   public function testLogStepFinishWithCustomPrefix(): void {
     self::logSetVerbose(TRUE);
 
@@ -338,9 +273,6 @@ final class LoggerTraitTest extends UnitTestCase {
     }
   }
 
-  /**
-   * Test logStepFinish method with verbose mode disabled.
-   */
   #[DoesNotPerformAssertions]
   public function testLogStepFinishSilentMode(): void {
     self::logSetVerbose(FALSE);
@@ -349,9 +281,6 @@ final class LoggerTraitTest extends UnitTestCase {
     self::logStepFinish('Silent step finish');
   }
 
-  /**
-   * Test logSubstep method with verbose mode enabled.
-   */
   #[DoesNotPerformAssertions]
   public function testLogSubstepVerboseMode(): void {
     self::logSetVerbose(TRUE);
@@ -360,9 +289,6 @@ final class LoggerTraitTest extends UnitTestCase {
     self::logSubstep('Processing substep 2');
   }
 
-  /**
-   * Test logSubstep method with verbose mode disabled.
-   */
   #[DoesNotPerformAssertions]
   public function testLogSubstepSilentMode(): void {
     self::logSetVerbose(FALSE);
@@ -370,9 +296,6 @@ final class LoggerTraitTest extends UnitTestCase {
     self::logSubstep('Silent substep');
   }
 
-  /**
-   * Test logNote method with verbose mode enabled.
-   */
   #[DoesNotPerformAssertions]
   public function testLogNoteVerboseMode(): void {
     self::logSetVerbose(TRUE);
@@ -381,9 +304,6 @@ final class LoggerTraitTest extends UnitTestCase {
     self::logNote('Another note with details');
   }
 
-  /**
-   * Test logNote method with verbose mode disabled.
-   */
   #[DoesNotPerformAssertions]
   public function testLogNoteSilentMode(): void {
     self::logSetVerbose(FALSE);
@@ -391,9 +311,6 @@ final class LoggerTraitTest extends UnitTestCase {
     self::logNote('Silent note');
   }
 
-  /**
-   * Test step logging workflow - with visual output for inspection.
-   */
   public function testLogStepWorkflow(): void {
     self::logSetVerbose(TRUE);
 
@@ -415,11 +332,6 @@ final class LoggerTraitTest extends UnitTestCase {
     $this->assertStringContainsString('    > Performing calculations', $output);
   }
 
-  /**
-   * Test that step methods respect verbose mode.
-   *
-   * With visual output for inspection.
-   */
   public function testLogStepMethodsRespectVerboseMode(): void {
     self::logSetVerbose(FALSE);
     self::logStepStart('Silent step');
@@ -452,9 +364,6 @@ final class LoggerTraitTest extends UnitTestCase {
     $this->assertStringContainsString('    > Verbose note', $verbose_output);
   }
 
-  /**
-   * Test elapsed time calculation and formatting.
-   */
   #[DoesNotPerformAssertions]
   public function testLogStepElapsedTime(): void {
     self::logSetVerbose(TRUE);
@@ -465,9 +374,6 @@ final class LoggerTraitTest extends UnitTestCase {
     self::logStepFinish('Timed step completed');
   }
 
-  /**
-   * Test logStepFinish without corresponding logStepStart.
-   */
   #[DoesNotPerformAssertions]
   public function testLogStepFinishWithoutStart(): void {
     self::logSetVerbose(TRUE);
@@ -476,9 +382,6 @@ final class LoggerTraitTest extends UnitTestCase {
     self::logStepFinish('Orphan step');
   }
 
-  /**
-   * Test step restart behavior.
-   */
   #[DoesNotPerformAssertions]
   public function testLogStepRestart(): void {
     self::logSetVerbose(TRUE);
@@ -493,9 +396,6 @@ final class LoggerTraitTest extends UnitTestCase {
     self::logStepFinish('Second step completed');
   }
 
-  /**
-   * Test step name mismatch behavior.
-   */
   #[DoesNotPerformAssertions]
   public function testLogStepNameMismatch(): void {
     self::logSetVerbose(TRUE);
@@ -516,9 +416,6 @@ final class LoggerTraitTest extends UnitTestCase {
     self::logStepFinish('Current method');
   }
 
-  /**
-   * Test logFormatElapsedTime method with various durations.
-   */
   #[DataProvider('dataProviderLogFormatElapsedTime')]
   public function testLogFormatElapsedTime(float $input_seconds, string $expected_output): void {
     $reflection_class = new \ReflectionClass(self::class);
@@ -529,10 +426,7 @@ final class LoggerTraitTest extends UnitTestCase {
   }
 
   /**
-   * Provides test data for logFormatElapsedTime method.
-   *
    * @return \Iterator<string, array{float, string}>
-   *   Test cases: [input_seconds, expected_output]
    */
   public static function dataProviderLogFormatElapsedTime(): \Iterator {
     yield 'short_duration' => [5.3, '5s'];
@@ -545,9 +439,6 @@ final class LoggerTraitTest extends UnitTestCase {
     yield 'complex_duration' => [345.4, '5m 45s'];
   }
 
-  /**
-   * Test logStepSummary with verbose mode disabled.
-   */
   public function testLogStepSummarySilentMode(): void {
     self::logSetVerbose(FALSE);
 
@@ -562,9 +453,6 @@ final class LoggerTraitTest extends UnitTestCase {
     $this->assertSame('', $output);
   }
 
-  /**
-   * Test logStepSummary with completed and running steps.
-   */
   public function testLogStepSummaryWithMixedSteps(): void {
     self::logStepStart('Completed step');
     // Delay long enough to show measurable time.
@@ -580,9 +468,6 @@ final class LoggerTraitTest extends UnitTestCase {
     $this->assertStringContainsString('Running', $result);
   }
 
-  /**
-   * Test logStepSummary with custom title.
-   */
   public function testLogStepSummaryWithCustomTitle(): void {
     self::logStepStart('Test step');
     self::logStepFinish('Test step');
@@ -592,9 +477,6 @@ final class LoggerTraitTest extends UnitTestCase {
     $this->assertStringContainsString('testLogStepSummaryWithCustomTitle', $result);
   }
 
-  /**
-   * Test multiple step tracking and summary.
-   */
   public function testLogStepMultipleTracking(): void {
     self::logStepStart('StepOne');
     self::logStepFinish('StepOne');
@@ -611,9 +493,6 @@ final class LoggerTraitTest extends UnitTestCase {
     $this->assertStringContainsString('Running', $result);
   }
 
-  /**
-   * Test that all steps are tracked in the array.
-   */
   public function testLogStepArrayTracking(): void {
     self::logSetVerbose(TRUE);
 
@@ -648,9 +527,6 @@ final class LoggerTraitTest extends UnitTestCase {
     $this->assertSame('testLogStepArrayTracking', $steps[1]['name']);
   }
 
-  /**
-   * Test logSetOutputStream method.
-   */
   public function testLogSetOutputStream(): void {
     self::logSetVerbose(TRUE);
 
@@ -669,9 +545,6 @@ final class LoggerTraitTest extends UnitTestCase {
     fclose($custom_buffer);
   }
 
-  /**
-   * Test output stream fallback to STDERR when set to NULL.
-   */
   public function testLogGetOutputStreamFallback(): void {
     self::logSetVerbose(TRUE);
 
@@ -684,9 +557,6 @@ final class LoggerTraitTest extends UnitTestCase {
     $this->assertSame(STDERR, $stream);
   }
 
-  /**
-   * Test logSetOutputStream validation with invalid input.
-   */
   #[DataProvider('dataProviderLogSetOutputStreamWithInvalidInput')]
   public function testLogSetOutputStreamWithInvalidInput(mixed $invalid_input): void {
     $this->expectException(\InvalidArgumentException::class);
@@ -697,10 +567,7 @@ final class LoggerTraitTest extends UnitTestCase {
   }
 
   /**
-   * Provides invalid input types for logSetOutputStream validation.
-   *
    * @return \Iterator<string, array{mixed}>
-   *   Test cases: [invalid_input]
    */
   public static function dataProviderLogSetOutputStreamWithInvalidInput(): \Iterator {
     yield 'string' => ['invalid'];
@@ -710,9 +577,6 @@ final class LoggerTraitTest extends UnitTestCase {
     yield 'boolean' => [TRUE];
   }
 
-  /**
-   * Test logSetOutputStream accepts valid resource.
-   */
   public function testLogSetOutputStreamWithValidResource(): void {
     $valid_resource = fopen('php://memory', 'r+');
     if ($valid_resource === FALSE) {
@@ -730,9 +594,6 @@ final class LoggerTraitTest extends UnitTestCase {
     fclose($valid_resource);
   }
 
-  /**
-   * Test substep and note output formatting.
-   */
   public function testLogSubstepAndNoteOutput(): void {
     self::logSetVerbose(TRUE);
 
@@ -744,9 +605,6 @@ final class LoggerTraitTest extends UnitTestCase {
     $this->assertStringContainsString('    > Important detail', $output);
   }
 
-  /**
-   * Test various logger methods in verbose and silent modes.
-   */
   #[DataProvider('dataProviderLogMethodsVerboseMode')]
   public function testLogMethodsVerboseMode(bool $verbose_mode, string $description, callable $test_method): void {
     self::logSetVerbose($verbose_mode);
@@ -764,10 +622,7 @@ final class LoggerTraitTest extends UnitTestCase {
   }
 
   /**
-   * Provides test data for verbose mode testing.
-   *
    * @return \Iterator<string, array{bool, string, callable}>
-   *   Test cases: [verbose_mode, test_description, test_method]
    */
   public static function dataProviderLogMethodsVerboseMode(): \Iterator {
     yield 'log_verbose' => [TRUE, 'log method', fn($self) => $self::log('Test message')];
@@ -783,8 +638,6 @@ final class LoggerTraitTest extends UnitTestCase {
   }
 
   /**
-   * Test step methods with various parameters.
-   *
    * @param array<string> $expected_output
    */
   #[DataProvider('dataProviderLogStepMethods')]
@@ -807,10 +660,7 @@ final class LoggerTraitTest extends UnitTestCase {
   }
 
   /**
-   * Provides test data for step method workflow testing.
-   *
    * @return \Iterator<string, array{(string|null), array<string>}>
-   *   Test cases: [message, expected_output_contains]
    */
   public static function dataProviderLogStepMethods(): \Iterator {
     yield 'basic_step_start' => ['Starting process', ['STEP START | testLogStepMethods', 'Starting process']];
@@ -820,8 +670,6 @@ final class LoggerTraitTest extends UnitTestCase {
   }
 
   /**
-   * Test section formatting with various parameters.
-   *
    * @param array<string> $expected_strings
    */
   #[DataProvider('dataProviderLogSectionFormatting')]
@@ -839,10 +687,7 @@ final class LoggerTraitTest extends UnitTestCase {
   }
 
   /**
-   * Provides test data for section formatting.
-   *
    * @return \Iterator<string, array{string, (string|null), bool, int, array<string>}>
-   *   Test cases: [title, message, double_border, min_width, expected_strings]
    */
   public static function dataProviderLogSectionFormatting(): \Iterator {
     yield 'basic_title_only' => ['BASIC TITLE', NULL, FALSE, 60, ['BASIC TITLE', '---']];
@@ -851,9 +696,6 @@ final class LoggerTraitTest extends UnitTestCase {
     yield 'wide_section' => ['WIDE', NULL, FALSE, 100, ['WIDE', '---']];
   }
 
-  /**
-   * Test step summary table output format.
-   */
   public function testLogStepSummaryTableFormat(): void {
     self::logStepStart('Test step');
     self::logStepFinish('Test completed');
@@ -869,9 +711,6 @@ final class LoggerTraitTest extends UnitTestCase {
     $this->assertStringContainsString('Running', $result);
   }
 
-  /**
-   * Test hierarchical step tracking with parent stack.
-   */
   public function testLogStepHierarchicalTracking(): void {
     self::logSetVerbose(TRUE);
 
@@ -923,9 +762,6 @@ final class LoggerTraitTest extends UnitTestCase {
     $this->assertEmpty($stack);
   }
 
-  /**
-   * Test configurable step indentation.
-   */
   public function testLogStepSummaryIndentation(): void {
     self::logStepStart('Parent step');
     self::logStepStart('Child step');
@@ -937,9 +773,6 @@ final class LoggerTraitTest extends UnitTestCase {
     $this->assertStringContainsString('    testLogStepSummaryIndentation', $result);
   }
 
-  /**
-   * Test step summary with hierarchical indentation display.
-   */
   public function testLogStepSummaryHierarchicalDisplay(): void {
     self::logStepStart('Main process');
     self::logStepStart('Sub process');
@@ -954,9 +787,6 @@ final class LoggerTraitTest extends UnitTestCase {
     $this->assertStringContainsString('    testLogStepSummaryHierarchicalDisplay', $result);
   }
 
-  /**
-   * Test logStepSummary returns string.
-   */
   public function testLogStepSummaryReturn(): void {
     self::logStepStart('testReturnMode');
     self::logStepFinish('testReturnMode');
@@ -967,17 +797,11 @@ final class LoggerTraitTest extends UnitTestCase {
     $this->assertStringContainsString('Complete', $result);
   }
 
-  /**
-   * Test logStepSummary with no steps.
-   */
   public function testLogStepSummaryEmpty(): void {
     $result = self::logStepSummary();
     $this->assertSame('', $result);
   }
 
-  /**
-   * Test logInfo method.
-   */
   public function testLogInfo(): void {
     self::logStepStart('TestStep');
     self::logStepFinish('TestStep');
@@ -989,9 +813,6 @@ final class LoggerTraitTest extends UnitTestCase {
     $this->assertStringContainsString('Complete', $info);
   }
 
-  /**
-   * Test logInfo with no steps.
-   */
   public function testLogInfoEmpty(): void {
     $info = $this->logInfo();
 
@@ -999,9 +820,6 @@ final class LoggerTraitTest extends UnitTestCase {
     $this->assertSame("STEP SUMMARY\n", $info);
   }
 
-  /**
-   * Recreates the memory buffer used to capture log output.
-   */
   protected function recreateLogBuffer(): void {
     $buffer = fopen('php://memory', 'r+');
 
@@ -1013,12 +831,6 @@ final class LoggerTraitTest extends UnitTestCase {
     self::logSetOutputStream($this->logBuffer);
   }
 
-  /**
-   * Gets the captured log output from the buffer.
-   *
-   * @return string
-   *   The captured output.
-   */
   protected function getCapturedOutput(): string {
     rewind($this->logBuffer);
     return stream_get_contents($this->logBuffer);

--- a/tests/Unit/LoggerTraitTest.php
+++ b/tests/Unit/LoggerTraitTest.php
@@ -32,12 +32,7 @@ final class LoggerTraitTest extends UnitTestCase {
     parent::setUp();
     self::logSetVerbose(FALSE);
 
-    $buffer = fopen('php://memory', 'r+');
-    if ($buffer === FALSE) {
-      throw new \RuntimeException('Failed to create memory buffer');
-    }
-    $this->logBuffer = $buffer;
-    self::logSetOutputStream($this->logBuffer);
+    $this->recreateLogBuffer();
 
     $reflection_class = new \ReflectionClass(self::class);
     $steps_property = $reflection_class->getProperty('logSteps');
@@ -61,17 +56,6 @@ final class LoggerTraitTest extends UnitTestCase {
   }
 
   /**
-   * Gets the captured log output from the buffer.
-   *
-   * @return string
-   *   The captured output.
-   */
-  protected function getCapturedOutput(): string {
-    rewind($this->logBuffer);
-    return stream_get_contents($this->logBuffer);
-  }
-
-  /**
    * Test verbose mode setter and getter.
    */
   public function testVerboseMode(): void {
@@ -84,12 +68,7 @@ final class LoggerTraitTest extends UnitTestCase {
     $this->assertStringContainsString('Verbose Section', $output);
     $this->assertStringContainsString('Verbose content', $output);
 
-    $buffer = fopen('php://memory', 'r+');
-    if ($buffer === FALSE) {
-      throw new \RuntimeException('Failed to create memory buffer');
-    }
-    $this->logBuffer = $buffer;
-    self::logSetOutputStream($this->logBuffer);
+    $this->recreateLogBuffer();
 
     self::logSetVerbose(FALSE);
     self::log('Silent message');
@@ -152,25 +131,25 @@ final class LoggerTraitTest extends UnitTestCase {
   /**
    * Test logSection method with invalid min_width parameter.
    */
-  public function testLogSectionWithInvalidMinWidth(): void {
+  #[DataProvider('dataProviderLogSectionWithInvalidMinWidth')]
+  public function testLogSectionWithInvalidMinWidth(int $min_width): void {
     self::logSetVerbose(TRUE);
 
     $this->expectException(\InvalidArgumentException::class);
     $this->expectExceptionMessage('Minimum width must be a positive integer.');
 
-    self::logSection('TEST TITLE', NULL, FALSE, 0);
+    self::logSection('TEST TITLE', NULL, FALSE, $min_width);
   }
 
   /**
-   * Test logSection method with negative min_width parameter.
+   * Provides invalid min_width values for logSection validation.
+   *
+   * @return \Iterator<string, array{int}>
+   *   Test cases: [min_width]
    */
-  public function testLogSectionWithNegativeMinWidth(): void {
-    self::logSetVerbose(TRUE);
-
-    $this->expectException(\InvalidArgumentException::class);
-    $this->expectExceptionMessage('Minimum width must be a positive integer.');
-
-    self::logSection('TEST TITLE', NULL, FALSE, -10);
+  public static function dataProviderLogSectionWithInvalidMinWidth(): \Iterator {
+    yield 'zero' => [0];
+    yield 'negative' => [-10];
   }
 
   /**
@@ -228,7 +207,7 @@ final class LoggerTraitTest extends UnitTestCase {
    * Test logFile method when verbose mode is disabled.
    */
   #[DoesNotPerformAssertions]
-  public function testLogFileWithVerboseDisabled(): void {
+  public function testLogFileSilentMode(): void {
     self::logSetVerbose(FALSE);
 
     $temp_file = tempnam(sys_get_temp_dir(), 'logger_test');
@@ -243,7 +222,7 @@ final class LoggerTraitTest extends UnitTestCase {
    * Test logSection method when verbose mode is disabled.
    */
   #[DoesNotPerformAssertions]
-  public function testLogSectionWithVerboseDisabled(): void {
+  public function testLogSectionSilentMode(): void {
     self::logSetVerbose(FALSE);
 
     self::logSection('TEST TITLE', 'Test message');
@@ -415,7 +394,7 @@ final class LoggerTraitTest extends UnitTestCase {
   /**
    * Test step logging workflow - with visual output for inspection.
    */
-  public function testStepLoggingWorkflow(): void {
+  public function testLogStepWorkflow(): void {
     self::logSetVerbose(TRUE);
 
     self::logStepStart('Test workflow');
@@ -426,8 +405,8 @@ final class LoggerTraitTest extends UnitTestCase {
     self::logStepFinish('Test workflow completed');
 
     $output = $this->getCapturedOutput();
-    $this->assertStringContainsString('STEP START | testStepLoggingWorkflow', $output);
-    $this->assertStringContainsString('STEP DONE | testStepLoggingWorkflow | 0s', $output);
+    $this->assertStringContainsString('STEP START | testLogStepWorkflow', $output);
+    $this->assertStringContainsString('STEP DONE | testLogStepWorkflow | 0s', $output);
     $this->assertStringContainsString('Test workflow', $output);
     $this->assertStringContainsString('Test workflow completed', $output);
     $this->assertStringContainsString('  --> Initializing', $output);
@@ -441,7 +420,7 @@ final class LoggerTraitTest extends UnitTestCase {
    *
    * With visual output for inspection.
    */
-  public function testStepMethodsRespectVerboseMode(): void {
+  public function testLogStepMethodsRespectVerboseMode(): void {
     self::logSetVerbose(FALSE);
     self::logStepStart('Silent step');
     self::logSubstep('Silent substep');
@@ -451,12 +430,7 @@ final class LoggerTraitTest extends UnitTestCase {
     $silent_output = $this->getCapturedOutput();
     $this->assertSame('', $silent_output);
 
-    $buffer = fopen('php://memory', 'r+');
-    if ($buffer === FALSE) {
-      throw new \RuntimeException('Failed to create memory buffer');
-    }
-    $this->logBuffer = $buffer;
-    self::logSetOutputStream($this->logBuffer);
+    $this->recreateLogBuffer();
 
     // Clear steps tracked by the silent calls to avoid interference.
     $reflection_class = new \ReflectionClass(self::class);
@@ -470,8 +444,8 @@ final class LoggerTraitTest extends UnitTestCase {
     self::logStepFinish('Verbose step end');
 
     $verbose_output = $this->getCapturedOutput();
-    $this->assertStringContainsString('STEP START | testStepMethodsRespectVerboseMode', $verbose_output);
-    $this->assertStringContainsString('STEP DONE | testStepMethodsRespectVerboseMode | 0s', $verbose_output);
+    $this->assertStringContainsString('STEP START | testLogStepMethodsRespectVerboseMode', $verbose_output);
+    $this->assertStringContainsString('STEP DONE | testLogStepMethodsRespectVerboseMode | 0s', $verbose_output);
     $this->assertStringContainsString('Verbose step', $verbose_output);
     $this->assertStringContainsString('Verbose step end', $verbose_output);
     $this->assertStringContainsString('  --> Verbose substep', $verbose_output);
@@ -482,7 +456,7 @@ final class LoggerTraitTest extends UnitTestCase {
    * Test elapsed time calculation and formatting.
    */
   #[DoesNotPerformAssertions]
-  public function testElapsedTimeCalculation(): void {
+  public function testLogStepElapsedTime(): void {
     self::logSetVerbose(TRUE);
 
     self::logStepStart('Timed step');
@@ -506,7 +480,7 @@ final class LoggerTraitTest extends UnitTestCase {
    * Test step restart behavior.
    */
   #[DoesNotPerformAssertions]
-  public function testStepRestart(): void {
+  public function testLogStepRestart(): void {
     self::logSetVerbose(TRUE);
 
     self::logStepStart('First step');
@@ -523,7 +497,7 @@ final class LoggerTraitTest extends UnitTestCase {
    * Test step name mismatch behavior.
    */
   #[DoesNotPerformAssertions]
-  public function testStepNameMismatch(): void {
+  public function testLogStepNameMismatch(): void {
     self::logSetVerbose(TRUE);
 
     $reflection_class = new \ReflectionClass(self::class);
@@ -545,8 +519,8 @@ final class LoggerTraitTest extends UnitTestCase {
   /**
    * Test logFormatElapsedTime method with various durations.
    */
-  #[DataProvider('dataProviderFormatElapsedTime')]
-  public function testFormatElapsedTime(float $input_seconds, string $expected_output): void {
+  #[DataProvider('dataProviderLogFormatElapsedTime')]
+  public function testLogFormatElapsedTime(float $input_seconds, string $expected_output): void {
     $reflection_class = new \ReflectionClass(self::class);
     $method = $reflection_class->getMethod('logFormatElapsedTime');
 
@@ -560,7 +534,7 @@ final class LoggerTraitTest extends UnitTestCase {
    * @return \Iterator<string, array{float, string}>
    *   Test cases: [input_seconds, expected_output]
    */
-  public static function dataProviderFormatElapsedTime(): \Iterator {
+  public static function dataProviderLogFormatElapsedTime(): \Iterator {
     yield 'short_duration' => [5.3, '5s'];
     yield 'thirty_seconds' => [30.2, '30s'];
     yield 'almost_minute' => [59.4, '59s'];
@@ -574,18 +548,13 @@ final class LoggerTraitTest extends UnitTestCase {
   /**
    * Test logStepSummary with verbose mode disabled.
    */
-  public function testLogStepSummaryWithVerboseDisabled(): void {
+  public function testLogStepSummarySilentMode(): void {
     self::logSetVerbose(FALSE);
 
     self::logStepStart('Test step');
     self::logStepFinish('Test step');
 
-    $buffer = fopen('php://memory', 'r+');
-    if ($buffer === FALSE) {
-      throw new \RuntimeException('Failed to create memory buffer');
-    }
-    $this->logBuffer = $buffer;
-    self::logSetOutputStream($this->logBuffer);
+    $this->recreateLogBuffer();
 
     self::logStepSummary();
 
@@ -626,7 +595,7 @@ final class LoggerTraitTest extends UnitTestCase {
   /**
    * Test multiple step tracking and summary.
    */
-  public function testMultipleStepTracking(): void {
+  public function testLogStepMultipleTracking(): void {
     self::logStepStart('StepOne');
     self::logStepFinish('StepOne');
 
@@ -637,7 +606,7 @@ final class LoggerTraitTest extends UnitTestCase {
     // Leave StepThree running.
     $result = self::logStepSummary();
 
-    $this->assertStringContainsString('testMultipleStepTracking', $result);
+    $this->assertStringContainsString('testLogStepMultipleTracking', $result);
     $this->assertStringContainsString('Complete', $result);
     $this->assertStringContainsString('Running', $result);
   }
@@ -645,7 +614,7 @@ final class LoggerTraitTest extends UnitTestCase {
   /**
    * Test that all steps are tracked in the array.
    */
-  public function testStepArrayTracking(): void {
+  public function testLogStepArrayTracking(): void {
     self::logSetVerbose(TRUE);
 
     $reflection_class = new \ReflectionClass(self::class);
@@ -659,7 +628,7 @@ final class LoggerTraitTest extends UnitTestCase {
     $this->assertIsArray($steps);
     $this->assertCount(1, $steps);
     // @phpstan-ignore-next-line offsetAccess.nonOffsetAccessible
-    $this->assertSame('testStepArrayTracking', $steps[0]['name']);
+    $this->assertSame('testLogStepArrayTracking', $steps[0]['name']);
     // @phpstan-ignore-next-line offsetAccess.nonOffsetAccessible
     $this->assertNull($steps[0]['end_time']);
 
@@ -676,18 +645,18 @@ final class LoggerTraitTest extends UnitTestCase {
     $this->assertIsArray($steps);
     $this->assertCount(2, $steps);
     // @phpstan-ignore-next-line offsetAccess.nonOffsetAccessible
-    $this->assertSame('testStepArrayTracking', $steps[1]['name']);
+    $this->assertSame('testLogStepArrayTracking', $steps[1]['name']);
   }
 
   /**
    * Test logSetOutputStream method.
    */
-  public function testLoggerSetOutputStream(): void {
+  public function testLogSetOutputStream(): void {
     self::logSetVerbose(TRUE);
 
     $custom_buffer = fopen('php://memory', 'r+');
     if ($custom_buffer === FALSE) {
-      throw new \RuntimeException('Failed to create custom buffer');
+      throw new \RuntimeException('Failed to create custom buffer.');
     }
     self::logSetOutputStream($custom_buffer);
 
@@ -703,7 +672,7 @@ final class LoggerTraitTest extends UnitTestCase {
   /**
    * Test output stream fallback to STDERR when set to NULL.
    */
-  public function testLoggerOutputStreamFallback(): void {
+  public function testLogGetOutputStreamFallback(): void {
     self::logSetVerbose(TRUE);
 
     self::logSetOutputStream(NULL);
@@ -718,45 +687,36 @@ final class LoggerTraitTest extends UnitTestCase {
   /**
    * Test logSetOutputStream validation with invalid input.
    */
-  public function testLoggerSetOutputStreamWithInvalidInput(): void {
+  #[DataProvider('dataProviderLogSetOutputStreamWithInvalidInput')]
+  public function testLogSetOutputStreamWithInvalidInput(mixed $invalid_input): void {
     $this->expectException(\InvalidArgumentException::class);
     $this->expectExceptionMessage('Stream must be a valid resource or NULL.');
 
     // @phpstan-ignore-next-line argument.type
-    self::logSetOutputStream('invalid_stream');
+    self::logSetOutputStream($invalid_input);
   }
 
   /**
-   * Test logSetOutputStream validation with various invalid types.
+   * Provides invalid input types for logSetOutputStream validation.
+   *
+   * @return \Iterator<string, array{mixed}>
+   *   Test cases: [invalid_input]
    */
-  public function testLoggerSetOutputStreamWithVariousInvalidTypes(): void {
-    $invalid_inputs = [
-      'string' => 'invalid',
-      'integer' => 123,
-      'array' => [],
-      'object' => new \stdClass(),
-      'boolean' => TRUE,
-    ];
-
-    foreach ($invalid_inputs as $type => $invalid_input) {
-      try {
-        // @phpstan-ignore-next-line argument.type
-        self::logSetOutputStream($invalid_input);
-        $this->fail(sprintf('Expected InvalidArgumentException for %s input', $type));
-      }
-      catch (\InvalidArgumentException $e) {
-        $this->assertSame('Stream must be a valid resource or NULL.', $e->getMessage());
-      }
-    }
+  public static function dataProviderLogSetOutputStreamWithInvalidInput(): \Iterator {
+    yield 'string' => ['invalid'];
+    yield 'integer' => [123];
+    yield 'array' => [[]];
+    yield 'object' => [new \stdClass()];
+    yield 'boolean' => [TRUE];
   }
 
   /**
    * Test logSetOutputStream accepts valid resource.
    */
-  public function testLoggerSetOutputStreamWithValidResource(): void {
+  public function testLogSetOutputStreamWithValidResource(): void {
     $valid_resource = fopen('php://memory', 'r+');
     if ($valid_resource === FALSE) {
-      throw new \RuntimeException('Failed to create test resource');
+      throw new \RuntimeException('Failed to create test resource.');
     }
 
     self::logSetOutputStream($valid_resource);
@@ -773,7 +733,7 @@ final class LoggerTraitTest extends UnitTestCase {
   /**
    * Test substep and note output formatting.
    */
-  public function testSubstepAndNoteOutput(): void {
+  public function testLogSubstepAndNoteOutput(): void {
     self::logSetVerbose(TRUE);
 
     self::logSubstep('Processing data');
@@ -787,8 +747,8 @@ final class LoggerTraitTest extends UnitTestCase {
   /**
    * Test various logger methods in verbose and silent modes.
    */
-  #[DataProvider('dataProviderLoggerMethodsVerboseMode')]
-  public function testLoggerMethodsVerboseMode(bool $verbose_mode, string $description, callable $test_method): void {
+  #[DataProvider('dataProviderLogMethodsVerboseMode')]
+  public function testLogMethodsVerboseMode(bool $verbose_mode, string $description, callable $test_method): void {
     self::logSetVerbose($verbose_mode);
 
     $test_method(self::class);
@@ -809,7 +769,7 @@ final class LoggerTraitTest extends UnitTestCase {
    * @return \Iterator<string, array{bool, string, callable}>
    *   Test cases: [verbose_mode, test_description, test_method]
    */
-  public static function dataProviderLoggerMethodsVerboseMode(): \Iterator {
+  public static function dataProviderLogMethodsVerboseMode(): \Iterator {
     yield 'log_verbose' => [TRUE, 'log method', fn($self) => $self::log('Test message')];
     yield 'log_silent' => [FALSE, 'log method', fn($self) => $self::log('Test message')];
     yield 'log_substep_verbose' => [TRUE, 'logSubstep method', fn($self) => $self::logSubstep('Test substep')];
@@ -827,8 +787,8 @@ final class LoggerTraitTest extends UnitTestCase {
    *
    * @param array<string> $expected_output
    */
-  #[DataProvider('dataProviderStepMethods')]
-  public function testStepMethods(string $step_name, ?string $message, array $expected_output): void {
+  #[DataProvider('dataProviderLogStepMethods')]
+  public function testLogStepMethods(?string $message, array $expected_output): void {
     self::logSetVerbose(TRUE);
 
     if (str_contains($expected_output[0], 'START')) {
@@ -849,14 +809,14 @@ final class LoggerTraitTest extends UnitTestCase {
   /**
    * Provides test data for step method workflow testing.
    *
-   * @return \Iterator<string, array{string, (string|null), array<string>}>
-   *   Test cases: [step_name, message, expected_output_contains]
+   * @return \Iterator<string, array{(string|null), array<string>}>
+   *   Test cases: [message, expected_output_contains]
    */
-  public static function dataProviderStepMethods(): \Iterator {
-    yield 'basic_step_start' => ['testStep', 'Starting process', ['STEP START | testStepMethods', 'Starting process']];
-    yield 'step_finish_with_message' => ['testStep', 'Process completed', ['STEP DONE | testStepMethods', 'Process completed', '0s']];
-    yield 'step_start_no_message' => ['testStep', NULL, ['STEP START | testStepMethods']];
-    yield 'step_finish_no_message' => ['testStep', NULL, ['STEP DONE | testStepMethods', '0s']];
+  public static function dataProviderLogStepMethods(): \Iterator {
+    yield 'basic_step_start' => ['Starting process', ['STEP START | testLogStepMethods', 'Starting process']];
+    yield 'step_finish_with_message' => ['Process completed', ['STEP DONE | testLogStepMethods', 'Process completed', '0s']];
+    yield 'step_start_no_message' => [NULL, ['STEP START | testLogStepMethods']];
+    yield 'step_finish_no_message' => [NULL, ['STEP DONE | testLogStepMethods', '0s']];
   }
 
   /**
@@ -864,16 +824,11 @@ final class LoggerTraitTest extends UnitTestCase {
    *
    * @param array<string> $expected_strings
    */
-  #[DataProvider('dataProviderSectionFormatting')]
-  public function testSectionFormatting(string $title, ?string $message, bool $double_border, int $min_width, array $expected_strings): void {
+  #[DataProvider('dataProviderLogSectionFormatting')]
+  public function testLogSectionFormatting(string $title, ?string $message, bool $double_border, int $min_width, array $expected_strings): void {
     self::logSetVerbose(TRUE);
 
-    $buffer = fopen('php://memory', 'r+');
-    if ($buffer === FALSE) {
-      throw new \RuntimeException('Failed to create memory buffer');
-    }
-    $this->logBuffer = $buffer;
-    self::logSetOutputStream($this->logBuffer);
+    $this->recreateLogBuffer();
 
     self::logSection($title, $message, $double_border, $min_width);
 
@@ -889,7 +844,7 @@ final class LoggerTraitTest extends UnitTestCase {
    * @return \Iterator<string, array{string, (string|null), bool, int, array<string>}>
    *   Test cases: [title, message, double_border, min_width, expected_strings]
    */
-  public static function dataProviderSectionFormatting(): \Iterator {
+  public static function dataProviderLogSectionFormatting(): \Iterator {
     yield 'basic_title_only' => ['BASIC TITLE', NULL, FALSE, 60, ['BASIC TITLE', '---']];
     yield 'title_with_message' => ['TITLE', 'Message content', FALSE, 60, ['TITLE', 'Message content', '---']];
     yield 'double_border' => ['DOUBLE', 'Double message', TRUE, 60, ['DOUBLE', 'Double message', '===']];
@@ -899,7 +854,7 @@ final class LoggerTraitTest extends UnitTestCase {
   /**
    * Test step summary table output format.
    */
-  public function testStepSummaryTableFormat(): void {
+  public function testLogStepSummaryTableFormat(): void {
     self::logStepStart('Test step');
     self::logStepFinish('Test completed');
 
@@ -917,7 +872,7 @@ final class LoggerTraitTest extends UnitTestCase {
   /**
    * Test hierarchical step tracking with parent stack.
    */
-  public function testHierarchicalStepTracking(): void {
+  public function testLogStepHierarchicalTracking(): void {
     self::logSetVerbose(TRUE);
 
     $reflection_class = new \ReflectionClass(self::class);
@@ -933,7 +888,7 @@ final class LoggerTraitTest extends UnitTestCase {
     $this->assertCount(1, $steps);
     // @phpstan-ignore-next-line offsetAccess.nonOffsetAccessible
     $this->assertEmpty($steps[0]['parent_stack']);
-    $this->assertSame(['testHierarchicalStepTracking'], $stack);
+    $this->assertSame(['testLogStepHierarchicalTracking'], $stack);
 
     self::logStepStart('Level 2');
     $steps = $steps_property->getValue();
@@ -942,8 +897,8 @@ final class LoggerTraitTest extends UnitTestCase {
     // @phpstan-ignore-next-line argument.type
     $this->assertCount(2, $steps);
     // @phpstan-ignore-next-line offsetAccess.nonOffsetAccessible
-    $this->assertSame(['testHierarchicalStepTracking'], $steps[1]['parent_stack']);
-    $this->assertSame(['testHierarchicalStepTracking', 'testHierarchicalStepTracking'], $stack);
+    $this->assertSame(['testLogStepHierarchicalTracking'], $steps[1]['parent_stack']);
+    $this->assertSame(['testLogStepHierarchicalTracking', 'testLogStepHierarchicalTracking'], $stack);
 
     self::logStepStart('Level 3');
     $steps = $steps_property->getValue();
@@ -952,16 +907,16 @@ final class LoggerTraitTest extends UnitTestCase {
     // @phpstan-ignore-next-line argument.type
     $this->assertCount(3, $steps);
     // @phpstan-ignore-next-line offsetAccess.nonOffsetAccessible
-    $this->assertSame(['testHierarchicalStepTracking', 'testHierarchicalStepTracking'], $steps[2]['parent_stack']);
-    $this->assertSame(['testHierarchicalStepTracking', 'testHierarchicalStepTracking', 'testHierarchicalStepTracking'], $stack);
+    $this->assertSame(['testLogStepHierarchicalTracking', 'testLogStepHierarchicalTracking'], $steps[2]['parent_stack']);
+    $this->assertSame(['testLogStepHierarchicalTracking', 'testLogStepHierarchicalTracking', 'testLogStepHierarchicalTracking'], $stack);
 
     self::logStepFinish('Level 3 done');
     $stack = $stack_property->getValue();
-    $this->assertSame(['testHierarchicalStepTracking', 'testHierarchicalStepTracking'], $stack);
+    $this->assertSame(['testLogStepHierarchicalTracking', 'testLogStepHierarchicalTracking'], $stack);
 
     self::logStepFinish('Level 2 done');
     $stack = $stack_property->getValue();
-    $this->assertSame(['testHierarchicalStepTracking'], $stack);
+    $this->assertSame(['testLogStepHierarchicalTracking'], $stack);
 
     self::logStepFinish('Level 1 done');
     $stack = $stack_property->getValue();
@@ -971,21 +926,21 @@ final class LoggerTraitTest extends UnitTestCase {
   /**
    * Test configurable step indentation.
    */
-  public function testConfigurableStepIndentation(): void {
+  public function testLogStepSummaryIndentation(): void {
     self::logStepStart('Parent step');
     self::logStepStart('Child step');
     self::logStepFinish('Child completed');
     self::logStepFinish('Parent completed');
 
     $result = self::logStepSummary('    ');
-    $this->assertStringContainsString('testConfigurableStepIndentation', $result);
-    $this->assertStringContainsString('    testConfigurableStepIndentation', $result);
+    $this->assertStringContainsString('testLogStepSummaryIndentation', $result);
+    $this->assertStringContainsString('    testLogStepSummaryIndentation', $result);
   }
 
   /**
    * Test step summary with hierarchical indentation display.
    */
-  public function testStepSummaryHierarchicalDisplay(): void {
+  public function testLogStepSummaryHierarchicalDisplay(): void {
     self::logStepStart('Main process');
     self::logStepStart('Sub process');
     self::logStepStart('Deep process');
@@ -994,9 +949,9 @@ final class LoggerTraitTest extends UnitTestCase {
     self::logStepFinish('Main process done');
 
     $result = self::logStepSummary();
-    $this->assertStringContainsString('testStepSummaryHierarchicalDisplay', $result);
-    $this->assertStringContainsString('  testStepSummaryHierarchicalDisplay', $result);
-    $this->assertStringContainsString('    testStepSummaryHierarchicalDisplay', $result);
+    $this->assertStringContainsString('testLogStepSummaryHierarchicalDisplay', $result);
+    $this->assertStringContainsString('  testLogStepSummaryHierarchicalDisplay', $result);
+    $this->assertStringContainsString('    testLogStepSummaryHierarchicalDisplay', $result);
   }
 
   /**
@@ -1023,25 +978,50 @@ final class LoggerTraitTest extends UnitTestCase {
   /**
    * Test logInfo method.
    */
-  public function testLoggerInfo(): void {
+  public function testLogInfo(): void {
     self::logStepStart('TestStep');
     self::logStepFinish('TestStep');
 
     $info = $this->logInfo();
 
     $this->assertStringContainsString('STEP SUMMARY', $info);
-    $this->assertStringContainsString('testLoggerInfo', $info);
+    $this->assertStringContainsString('testLogInfo', $info);
     $this->assertStringContainsString('Complete', $info);
   }
 
   /**
    * Test logInfo with no steps.
    */
-  public function testLoggerInfoEmpty(): void {
+  public function testLogInfoEmpty(): void {
     $info = $this->logInfo();
 
     $this->assertStringContainsString('STEP SUMMARY', $info);
     $this->assertSame("STEP SUMMARY\n", $info);
+  }
+
+  /**
+   * Recreates the memory buffer used to capture log output.
+   */
+  protected function recreateLogBuffer(): void {
+    $buffer = fopen('php://memory', 'r+');
+
+    if ($buffer === FALSE) {
+      throw new \RuntimeException('Failed to create memory buffer.');
+    }
+
+    $this->logBuffer = $buffer;
+    self::logSetOutputStream($this->logBuffer);
+  }
+
+  /**
+   * Gets the captured log output from the buffer.
+   *
+   * @return string
+   *   The captured output.
+   */
+  protected function getCapturedOutput(): string {
+    rewind($this->logBuffer);
+    return stream_get_contents($this->logBuffer);
   }
 
   /**

--- a/tests/Unit/ProcessTraitTest.php
+++ b/tests/Unit/ProcessTraitTest.php
@@ -567,7 +567,6 @@ EOL;
   }
 
   public function testProcessStreamingCallbackWithEmptyBuffer(): void {
-    // The callback captures output instead of writing to STDOUT.
     $captured_output = '';
     $test_callback = $this->makeStreamingCaptureCallback($captured_output);
 
@@ -578,7 +577,6 @@ EOL;
   }
 
   public function testProcessStreamingCallbackWithDifferentLineEndings(): void {
-    // The callback captures output instead of writing to STDOUT.
     $captured_output = '';
     $test_callback = $this->makeStreamingCaptureCallback($captured_output);
 
@@ -600,7 +598,6 @@ EOL;
   }
 
   public function testProcessStreamingCallbackWithErrorOutput(): void {
-    // The callback captures output instead of writing to STDOUT.
     $captured_output = '';
     $test_callback = $this->makeStreamingCaptureCallback($captured_output);
 

--- a/tests/Unit/ProcessTraitTest.php
+++ b/tests/Unit/ProcessTraitTest.php
@@ -646,8 +646,8 @@ EOL;
       "line1\nline2\n",
       "line1\r\nline2\r\n",
       "line1\rline2\r",
-      "single line",
-      "",
+      'single line',
+      '',
     ];
 
     foreach ($test_inputs as $input) {
@@ -1151,8 +1151,8 @@ EOL;
     $this->assertIsCallable($callback);
 
     // Empty strings avoid visible output.
-    $callback(Process::OUT, "");
-    $callback(Process::ERR, "");
+    $callback(Process::OUT, '');
+    $callback(Process::ERR, '');
   }
 
   #[DataProvider('dataProviderProcessStreamingOutputCallbackDimming')]

--- a/tests/Unit/ProcessTraitTest.php
+++ b/tests/Unit/ProcessTraitTest.php
@@ -227,7 +227,7 @@ final class ProcessTraitTest extends UnitTestCase {
     $this->assertProcessAnyOutputNotContains('Standard Content');
   }
 
-  public function testProcessAnyOutputAssertionsShortcutMode(): void {
+  public function testProcessAnyOutputContainsOrNotShortcutMode(): void {
     $this->processRun('echo', ['Test Output']);
 
     $this->assertProcessSuccessful();
@@ -240,7 +240,7 @@ final class ProcessTraitTest extends UnitTestCase {
     ]);
   }
 
-  public function testProcessAnyOutputAssertionsInconsistentPrefixUsage(): void {
+  public function testProcessAnyOutputContainsOrNotInconsistentPrefixUsage(): void {
     $this->processRun('echo', ['Test Output']);
 
     $this->expectException(\RuntimeException::class);
@@ -252,7 +252,7 @@ final class ProcessTraitTest extends UnitTestCase {
     ]);
   }
 
-  public function testProcessErrorOutputAssertionsInconsistentPrefixUsage(): void {
+  public function testProcessErrorOutputContainsOrNotInconsistentPrefixUsage(): void {
     $this->processRun('sh', ['-c', 'echo "Test Error" 1>&2']);
 
     $this->expectException(\RuntimeException::class);
@@ -264,7 +264,7 @@ final class ProcessTraitTest extends UnitTestCase {
     ]);
   }
 
-  public function testProcessOutputAssertionsInconsistentPrefixUsage(): void {
+  public function testProcessOutputContainsOrNotInconsistentPrefixUsage(): void {
     $this->processRun('echo', ['Test Output']);
 
     $this->expectException(\RuntimeException::class);
@@ -276,7 +276,7 @@ final class ProcessTraitTest extends UnitTestCase {
     ]);
   }
 
-  public function testProcessOutputExactMatch(): void {
+  public function testProcessOutputContainsOrNotExactMatch(): void {
     $this->processRun('echo', ['Hello World']);
 
     $this->assertProcessSuccessful();
@@ -290,7 +290,7 @@ final class ProcessTraitTest extends UnitTestCase {
     ]);
   }
 
-  public function testProcessErrorOutputExactMatch(): void {
+  public function testProcessErrorOutputContainsOrNotExactMatch(): void {
     $this->processRun('sh', ['-c', 'echo "Error Message" 1>&2']);
 
     $this->assertProcessSuccessful();
@@ -304,7 +304,7 @@ final class ProcessTraitTest extends UnitTestCase {
     ]);
   }
 
-  public function testProcessAnyOutputExactMatch(): void {
+  public function testProcessAnyOutputContainsOrNotExactMatch(): void {
     $this->processRun('sh', ['-c', 'echo "Standard"; echo "Error" 1>&2']);
 
     $this->assertProcessSuccessful();
@@ -318,7 +318,7 @@ final class ProcessTraitTest extends UnitTestCase {
     ]);
   }
 
-  public function testProcessOutputExactMatchMultiline(): void {
+  public function testProcessOutputContainsOrNotExactMatchMultiline(): void {
     $this->processRun('sh', ['-c', 'echo "Line 1"; echo "Line 2"; echo "Line 3"']);
 
     $this->assertProcessSuccessful();
@@ -366,8 +366,8 @@ final class ProcessTraitTest extends UnitTestCase {
     $this->processRun('echo', [], [], ['ENV1' => ['non-scalar', 'value']]);
   }
 
-  #[DataProvider('dataProviderAssertionsWhenNull')]
-  public function testAssertionsWhenNull(string $method, array $arguments): void {
+  #[DataProvider('dataProviderProcessAssertionsWhenNotInitialized')]
+  public function testProcessAssertionsWhenNotInitialized(string $method, array $arguments): void {
     $this->process = NULL;
 
     $this->expectException(ExpectationFailedException::class);
@@ -381,7 +381,7 @@ final class ProcessTraitTest extends UnitTestCase {
     $callable(...$arguments);
   }
 
-  public static function dataProviderAssertionsWhenNull(): \Iterator {
+  public static function dataProviderProcessAssertionsWhenNotInitialized(): \Iterator {
     yield 'successful' => ['assertProcessSuccessful', []];
     yield 'failed' => ['assertProcessFailed', []];
     yield 'output_contains' => ['assertProcessOutputContains', ['test']];
@@ -410,30 +410,10 @@ final class ProcessTraitTest extends UnitTestCase {
 
     $command = self::$fixtures . '/shell-command-failing.sh';
 
-    $reflection = new \ReflectionClass($this);
-    $property = $reflection->getProperty('processStreamingOutput');
-    $property->setValue($this, TRUE);
+    $this->processStreamingOutput = TRUE;
 
-    // The callback logic is duplicated here rather than invoked, so the test
-    // can capture what would have been streamed.
     $captured_output = '';
-    $capture_callback = function ($type, $buffer) use (&$captured_output): void {
-      $prefix = $type === Process::ERR ? self::$processStreamingErrorOutputChars : self::$processStreamingStandardOutputChars;
-
-      $parts = preg_split('/(\r\n|\n|\r)/', $buffer, -1, PREG_SPLIT_DELIM_CAPTURE);
-      $count = is_array($parts) ? count($parts) : 0;
-
-      for ($i = 0; $i < $count; $i += 2) {
-        $line = $parts[$i] ?? '';
-        $eol = $parts[$i + 1] ?? '';
-
-        if ($line === '' && $eol === '') {
-          continue;
-        }
-
-        $captured_output .= $prefix . $line . $eol;
-      }
-    };
+    $capture_callback = $this->makeStreamingCaptureCallback($captured_output);
 
     // Built directly rather than through processRun() so the capture callback
     // can be passed to run().
@@ -483,9 +463,7 @@ EOL;
   public function testProcessFormatOutput(): void {
     $this->processRun('echo', ['Standard output text']);
 
-    $reflection = new \ReflectionClass($this);
-    $method = $reflection->getMethod('processFormatOutput');
-    $formatted_output = $method->invoke($this);
+    $formatted_output = self::callProtectedMethod($this, 'processFormatOutput');
     $this->assertIsString($formatted_output);
 
     $this->assertStringContainsString('EXIT CODE: 0', $formatted_output);
@@ -497,9 +475,7 @@ EOL;
   public function testProcessFormatOutputWithError(): void {
     $this->processRun('sh', ['-c', 'echo "Process stdout message"; echo "Process stderr message" >&2; exit 1']);
 
-    $reflection = new \ReflectionClass($this);
-    $method = $reflection->getMethod('processFormatOutput');
-    $formatted_output = $method->invoke($this);
+    $formatted_output = self::callProtectedMethod($this, 'processFormatOutput');
     $this->assertIsString($formatted_output);
 
     $this->assertStringContainsString('EXIT CODE: 1', $formatted_output);
@@ -514,9 +490,7 @@ EOL;
   public function testProcessFormatOutputWithEmptyOutput(): void {
     $this->processRun('true');
 
-    $reflection = new \ReflectionClass($this);
-    $method = $reflection->getMethod('processFormatOutput');
-    $formatted_output = $method->invoke($this);
+    $formatted_output = self::callProtectedMethod($this, 'processFormatOutput');
     $this->assertIsString($formatted_output);
 
     $this->assertStringContainsString('EXIT CODE: 0', $formatted_output);
@@ -586,9 +560,7 @@ EOL;
   public function testProcessFormatOutputWhenNotInitialized(): void {
     $this->process = NULL;
 
-    $reflection = new \ReflectionClass($this);
-    $method = $reflection->getMethod('processFormatOutput');
-    $formatted_output = $method->invoke($this);
+    $formatted_output = self::callProtectedMethod($this, 'processFormatOutput');
     $this->assertIsString($formatted_output);
 
     $this->assertStringContainsString('Process is not initialized.', $formatted_output);
@@ -597,23 +569,7 @@ EOL;
   public function testProcessStreamingCallbackWithEmptyBuffer(): void {
     // The callback captures output instead of writing to STDOUT.
     $captured_output = '';
-    $test_callback = function ($type, $buffer) use (&$captured_output): void {
-      $prefix = $type === Process::ERR ? self::$processStreamingErrorOutputChars : self::$processStreamingStandardOutputChars;
-
-      $parts = preg_split('/(\r\n|\n|\r)/', $buffer, -1, PREG_SPLIT_DELIM_CAPTURE);
-      $count = is_array($parts) ? count($parts) : 0;
-
-      for ($i = 0; $i < $count; $i += 2) {
-        $line = $parts[$i] ?? '';
-        $eol = $parts[$i + 1] ?? '';
-
-        if ($line === '' && $eol === '') {
-          continue;
-        }
-
-        $captured_output .= $prefix . $line . $eol;
-      }
-    };
+    $test_callback = $this->makeStreamingCaptureCallback($captured_output);
 
     $test_callback(Process::OUT, '');
     $test_callback(Process::ERR, '');
@@ -624,23 +580,7 @@ EOL;
   public function testProcessStreamingCallbackWithDifferentLineEndings(): void {
     // The callback captures output instead of writing to STDOUT.
     $captured_output = '';
-    $test_callback = function ($type, $buffer) use (&$captured_output): void {
-      $prefix = $type === Process::ERR ? self::$processStreamingErrorOutputChars : self::$processStreamingStandardOutputChars;
-
-      $parts = preg_split('/(\r\n|\n|\r)/', $buffer, -1, PREG_SPLIT_DELIM_CAPTURE);
-      $count = is_array($parts) ? count($parts) : 0;
-
-      for ($i = 0; $i < $count; $i += 2) {
-        $line = $parts[$i] ?? '';
-        $eol = $parts[$i + 1] ?? '';
-
-        if ($line === '' && $eol === '') {
-          continue;
-        }
-
-        $captured_output .= $prefix . $line . $eol;
-      }
-    };
+    $test_callback = $this->makeStreamingCaptureCallback($captured_output);
 
     $test_inputs = [
       "line1\nline2\n",
@@ -662,23 +602,7 @@ EOL;
   public function testProcessStreamingCallbackWithErrorOutput(): void {
     // The callback captures output instead of writing to STDOUT.
     $captured_output = '';
-    $test_callback = function ($type, $buffer) use (&$captured_output): void {
-      $prefix = $type === Process::ERR ? self::$processStreamingErrorOutputChars : self::$processStreamingStandardOutputChars;
-
-      $parts = preg_split('/(\r\n|\n|\r)/', $buffer, -1, PREG_SPLIT_DELIM_CAPTURE);
-      $count = is_array($parts) ? count($parts) : 0;
-
-      for ($i = 0; $i < $count; $i += 2) {
-        $line = $parts[$i] ?? '';
-        $eol = $parts[$i + 1] ?? '';
-
-        if ($line === '' && $eol === '') {
-          continue;
-        }
-
-        $captured_output .= $prefix . $line . $eol;
-      }
-    };
+    $test_callback = $this->makeStreamingCaptureCallback($captured_output);
 
     $test_callback(Process::ERR, "error message\n");
     $test_callback(Process::OUT, "standard message\n");
@@ -709,7 +633,7 @@ EOL;
 
   public function testProcessRunWithNonEmptyInputs(): void {
     if (DIRECTORY_SEPARATOR === '\\') {
-      $this->markTestSkipped('Requires POSIX utilities');
+      $this->markTestSkipped('Requires POSIX utilities.');
     }
 
     // Non-empty inputs trigger the implode path.
@@ -724,7 +648,7 @@ EOL;
   #[DataProvider('dataProviderProcessRunWithCommandString')]
   public function testProcessRunWithCommandString(string $command_string, array $additional_args, array $expected_output): void {
     if (DIRECTORY_SEPARATOR === '\\' && str_starts_with($command_string, 'printf')) {
-      $this->markTestSkipped('Requires POSIX utilities');
+      $this->markTestSkipped('Requires POSIX utilities.');
     }
 
     $this->processRun($command_string, $additional_args);
@@ -771,6 +695,46 @@ EOL;
       ['--author=John'],
       ['--author=John', '--message=Initial commit'],
     ];
+    yield 'array_arguments_form' => [
+      'echo',
+      ['hello', 'world'],
+      ['hello world'],
+    ];
+    yield 'multiword_command_string' => [
+      'echo test1 test2',
+      [],
+      ['test1 test2'],
+    ];
+    yield 'special_characters' => [
+      'echo "Hello! @#$%^&*()"',
+      [],
+      ['Hello! @#$%^&*()'],
+    ];
+    yield 'file_flags' => [
+      'echo -e "line1\\nline2"',
+      [],
+      ['line1'],
+    ];
+    yield 'parsed_then_explicit_arguments' => [
+      'echo parsed1 parsed2',
+      ['explicit1', 'explicit2'],
+      ['parsed1 parsed2 explicit1 explicit2'],
+    ];
+    yield 'flag_argument_order' => [
+      'echo --parsed-flag',
+      ['--explicit-flag'],
+      ['--parsed-flag --explicit-flag'],
+    ];
+    yield 'explicit_arguments_appended' => [
+      'echo default-arg1 default-arg2',
+      ['override-arg1', 'override-arg2'],
+      ['default-arg1 default-arg2 override-arg1 override-arg2'],
+    ];
+    yield 'end_of_options_with_explicit_args' => [
+      'echo command -- after-marker',
+      ['explicit'],
+      ['command explicit -- after-marker'],
+    ];
   }
 
   public function testProcessRunWithInvalidCommandString(): void {
@@ -801,63 +765,6 @@ EOL;
     $this->processRun('echo "unclosed quote');
   }
 
-  public function testProcessRunPreservesBackwardCompatibility(): void {
-    $this->processRun('echo', ['hello', 'world']);
-
-    $this->assertProcessSuccessful();
-    $this->assertProcessOutputContains('hello world');
-  }
-
-  public function testProcessRunCommandStringParsing(): void {
-    $this->processRun('echo test1 test2');
-
-    $this->assertProcessSuccessful();
-    $this->assertProcessOutputContains('test1 test2');
-  }
-
-  public function testProcessRunCommandStringWithSpecialCharacters(): void {
-    $this->processRun('echo "Hello! @#$%^&*()"');
-
-    $this->assertProcessSuccessful();
-    $this->assertProcessOutputContains('Hello! @#$%^&*()');
-  }
-
-  public function testProcessRunCommandStringWithFileFlags(): void {
-    $this->processRun('echo -e "line1\\nline2"');
-
-    $this->assertProcessSuccessful();
-    $this->assertProcessOutputContains('line1');
-  }
-
-  public function testProcessRunArgumentOverrideBehavior(): void {
-    $this->processRun('echo parsed1 parsed2', ['explicit1', 'explicit2']);
-
-    $this->assertProcessSuccessful();
-    $this->assertProcessOutputContains('parsed1 parsed2 explicit1 explicit2');
-  }
-
-  public function testProcessRunArgumentOrderWithFlags(): void {
-    $this->processRun('echo --parsed-flag', ['--explicit-flag']);
-
-    $this->assertProcessSuccessful();
-    $this->assertProcessOutputContains('--parsed-flag --explicit-flag');
-  }
-
-  public function testProcessRunExplicitArgumentsPrecedence(): void {
-    // Without an end-of-options marker, explicit arguments are appended.
-    $this->processRun('echo default-arg1 default-arg2', ['override-arg1', 'override-arg2']);
-
-    $this->assertProcessSuccessful();
-    $this->assertProcessOutputContains('default-arg1 default-arg2 override-arg1 override-arg2');
-  }
-
-  public function testProcessRunWithEndOfOptionsAndExplicitArgs(): void {
-    $this->processRun('echo command -- after-marker', ['explicit']);
-
-    $this->assertProcessSuccessful();
-    $this->assertProcessOutputContains('command explicit -- after-marker');
-  }
-
   public function testProcessRunWithIdleTimeout(): void {
     $this->processRun('echo', ['test'], [], [], 10, 5);
 
@@ -865,7 +772,7 @@ EOL;
     $this->assertProcessOutputContains('test');
   }
 
-  public function testStaticVariableAccess(): void {
+  public function testProcessStaticPropertyDefaults(): void {
     $this->assertSame('>> ', self::$processStreamingStandardOutputChars);
     $this->assertSame('XX ', self::$processStreamingErrorOutputChars);
     $this->assertStringContainsString('STANDARD OUTPUT', self::$processStandardOutputHeader);
@@ -876,15 +783,12 @@ EOL;
 
   #[DataProvider('dataProviderProcessParseCommand')]
   public function testProcessParseCommand(string $command, array $expected, ?string $exception_message = NULL): void {
-    $reflection = new \ReflectionClass($this);
-    $method = $reflection->getMethod('processParseCommand');
-
     if ($exception_message !== NULL) {
       $this->expectException(\InvalidArgumentException::class);
       $this->expectExceptionMessage($exception_message);
     }
 
-    $result = $method->invoke($this, $command);
+    $result = self::callProtectedMethod($this, 'processParseCommand', [$command]);
 
     if ($exception_message === NULL) {
       $this->assertSame($expected, $result);
@@ -1144,9 +1048,7 @@ EOL;
   }
 
   public function testProcessStreamingCallbackReturnsCallable(): void {
-    $reflection = new \ReflectionClass($this);
-    $method = $reflection->getMethod('processStreamingOutputCallback');
-    $callback = $method->invoke($this);
+    $callback = self::callProtectedMethod($this, 'processStreamingOutputCallback');
 
     $this->assertIsCallable($callback);
 
@@ -1197,39 +1099,6 @@ EOL;
     ];
   }
 
-  /**
-   * Runs a callback and returns what it wrote to STDOUT.
-   *
-   * @param callable $callback
-   *   The callback to run.
-   *
-   * @return string
-   *   Everything the callback wrote to STDOUT.
-   */
-  protected function captureStdout(callable $callback): string {
-    $name = 'phpunit_helpers_stream_capture';
-
-    if (!in_array($name, stream_get_filters(), TRUE)) {
-      stream_filter_register($name, StreamCaptureFilter::class);
-    }
-
-    StreamCaptureFilter::$captured = '';
-
-    $filter = stream_filter_append(STDOUT, $name, STREAM_FILTER_WRITE);
-    if ($filter === FALSE) {
-      throw new \RuntimeException('Unable to attach the capture filter to STDOUT.');
-    }
-
-    try {
-      $callback();
-    }
-    finally {
-      stream_filter_remove($filter);
-    }
-
-    return StreamCaptureFilter::$captured;
-  }
-
   public function testProcessRunWithZeroArguments(): void {
     $this->processRun('echo', []);
 
@@ -1250,7 +1119,7 @@ EOL;
 
   public function testProcessRunWithMixedScalarEnvironmentVariables(): void {
     if (DIRECTORY_SEPARATOR === '\\') {
-      $this->markTestSkipped('Requires POSIX utilities');
+      $this->markTestSkipped('Requires POSIX utilities.');
     }
 
     $this->processRun('printenv', [], [], [
@@ -1265,37 +1134,39 @@ EOL;
 
   public function testProcessRunWithEnvironmentVariableUnsetting(): void {
     if (DIRECTORY_SEPARATOR === '\\') {
-      $this->markTestSkipped('Requires POSIX utilities');
+      $this->markTestSkipped('Requires POSIX utilities.');
     }
 
     putenv('TEST_UNSET_VAR=initial_value');
-    $this->assertNotFalse(getenv('TEST_UNSET_VAR'));
 
-    // A FALSE value unsets the variable.
-    $this->processRun('printenv', [], [], [
-      'TEST_UNSET_VAR' => FALSE,
-      'TEST_KEEP_VAR' => 'keep_this',
-    ]);
+    try {
+      $this->assertNotFalse(getenv('TEST_UNSET_VAR'));
 
-    $this->assertProcessSuccessful();
+      // A FALSE value unsets the variable.
+      $this->processRun('printenv', [], [], [
+        'TEST_UNSET_VAR' => FALSE,
+        'TEST_KEEP_VAR' => 'keep_this',
+      ]);
 
-    $this->assertProcessOutputNotContains('TEST_UNSET_VAR=initial_value');
+      $this->assertProcessSuccessful();
 
-    $this->assertProcessOutputContains('TEST_KEEP_VAR=keep_this');
+      $this->assertProcessOutputNotContains('TEST_UNSET_VAR=initial_value');
 
-    putenv('TEST_UNSET_VAR');
+      $this->assertProcessOutputContains('TEST_KEEP_VAR=keep_this');
+    }
+    finally {
+      putenv('TEST_UNSET_VAR');
+    }
   }
 
   public function testProcessFormatOutputExitCodeDisplay(): void {
     if (DIRECTORY_SEPARATOR === '\\') {
-      $this->markTestSkipped('Requires POSIX utilities');
+      $this->markTestSkipped('Requires POSIX utilities.');
     }
 
     $this->processRun('sh', ['-c', 'exit 42']);
 
-    $reflection = new \ReflectionClass($this);
-    $method = $reflection->getMethod('processFormatOutput');
-    $formatted_output = $method->invoke($this);
+    $formatted_output = self::callProtectedMethod($this, 'processFormatOutput');
 
     $this->assertIsString($formatted_output);
     $this->assertStringContainsString('EXIT CODE: 42', $formatted_output);
@@ -1339,13 +1210,14 @@ EOL;
     $this->assertProcessFailed('Expected process to fail');
   }
 
-  public function testStreamingOutputWithDimmingEnabled(): void {
+  public function testProcessStreamingOutputWithDimmingEnabled(): void {
     $this->processStreamingOutput = TRUE;
     self::$processStreamingOutputShouldDim = TRUE;
 
-    $temp_file = tempnam(sys_get_temp_dir(), 'phpunit_stdout_test');
+    try {
+      $temp_file = tempnam(sys_get_temp_dir(), 'phpunit_stdout_test');
 
-    $test_script = sprintf('
+      $test_script = sprintf('
 <?php
 require_once "%s/vendor/autoload.php";
 use AlexSkrypnyk\PhpunitHelpers\Tests\Fixtures\StreamCaptureFilter;
@@ -1365,27 +1237,30 @@ $test->enableStreamingWithDimming();
 $test->processRun("echo", ["test output"]);
 ', getcwd());
 
-    file_put_contents($temp_file . '.php', $test_script);
-    $output = shell_exec('php ' . escapeshellarg($temp_file . '.php'));
-    unlink($temp_file . '.php');
-    unlink($temp_file);
+      file_put_contents($temp_file . '.php', $test_script);
+      $output = shell_exec('php ' . escapeshellarg($temp_file . '.php'));
+      unlink($temp_file . '.php');
+      unlink($temp_file);
 
-    $this->assertNotNull($output);
-    $output = (string) $output;
-    $this->assertStringContainsString("\033[2m", $output, 'Should contain ANSI dim start code');
-    $this->assertStringContainsString("\033[22m", $output, 'Should contain ANSI dim end code');
-    $this->assertStringContainsString('test output', $output, 'Should contain actual text');
-
-    $this->processStreamingOutput = FALSE;
+      $this->assertNotNull($output);
+      $output = (string) $output;
+      $this->assertStringContainsString("\033[2m", $output, 'Should contain ANSI dim start code');
+      $this->assertStringContainsString("\033[22m", $output, 'Should contain ANSI dim end code');
+      $this->assertStringContainsString('test output', $output, 'Should contain actual text');
+    }
+    finally {
+      $this->processStreamingOutput = FALSE;
+    }
   }
 
-  public function testStreamingOutputWithDimmingDisabled(): void {
+  public function testProcessStreamingOutputWithDimmingDisabled(): void {
     $this->processStreamingOutput = TRUE;
     self::$processStreamingOutputShouldDim = FALSE;
 
-    $temp_file = tempnam(sys_get_temp_dir(), 'phpunit_stdout_test');
+    try {
+      $temp_file = tempnam(sys_get_temp_dir(), 'phpunit_stdout_test');
 
-    $test_script = sprintf('
+      $test_script = sprintf('
 <?php
 require_once "%s/vendor/autoload.php";
 use AlexSkrypnyk\PhpunitHelpers\Tests\Fixtures\StreamCaptureFilter;
@@ -1405,67 +1280,118 @@ $test->enableStreamingWithoutDimming();
 $test->processRun("echo", ["test output"]);
 ', getcwd());
 
-    file_put_contents($temp_file . '.php', $test_script);
-    $output = shell_exec('php ' . escapeshellarg($temp_file . '.php'));
-    unlink($temp_file . '.php');
-    unlink($temp_file);
+      file_put_contents($temp_file . '.php', $test_script);
+      $output = shell_exec('php ' . escapeshellarg($temp_file . '.php'));
+      unlink($temp_file . '.php');
+      unlink($temp_file);
 
-    $this->assertNotNull($output);
-    $output = (string) $output;
-    $this->assertStringNotContainsString("\033[2m", $output, 'Should not contain ANSI dim start code');
-    $this->assertStringNotContainsString("\033[22m", $output, 'Should not contain ANSI dim end code');
-    $this->assertStringContainsString('test output', $output, 'Should contain actual text');
-
-    $this->processStreamingOutput = FALSE;
-    self::$processStreamingOutputShouldDim = TRUE;
+      $this->assertNotNull($output);
+      $output = (string) $output;
+      $this->assertStringNotContainsString("\033[2m", $output, 'Should not contain ANSI dim start code');
+      $this->assertStringNotContainsString("\033[22m", $output, 'Should not contain ANSI dim end code');
+      $this->assertStringContainsString('test output', $output, 'Should contain actual text');
+    }
+    finally {
+      $this->processStreamingOutput = FALSE;
+      self::$processStreamingOutputShouldDim = TRUE;
+    }
   }
 
-  public function testCustomFailureMessages(): void {
+  public function testAssertProcessOutputContainsWithCustomMessage(): void {
     $this->processRun('echo', ['test output']);
 
     $custom_message = 'This is a custom failure message';
 
-    $this->expectException(AssertionFailedError::class);
+    $this->expectException(ExpectationFailedException::class);
     $this->expectExceptionMessage($custom_message);
 
     $this->assertProcessOutputContains('nonexistent', $custom_message);
   }
 
-  #[DataProvider('dataProviderDim')]
-  public function testDim(string $text, string $eol, string $expected): void {
+  #[DataProvider('dataProviderProcessColorDim')]
+  public function testProcessColorDim(string $text, string $eol, string $expected): void {
     $this->assertSame($expected, self::processColorDim($text, $eol));
   }
 
-  public static function dataProviderDim(): \Iterator {
+  public static function dataProviderProcessColorDim(): \Iterator {
     yield 'empty' => [
       '',
       "\n",
       "\033[2m\033[22m",
     ];
-
     yield 'single_line' => [
       'test',
       "\n",
       "\033[2mtest\033[22m",
     ];
-
     yield 'multiple_lines' => [
       "one\ntwo",
       "\n",
       "\033[2mone\033[22m\n\033[2mtwo\033[22m",
     ];
-
     yield 'custom_eol' => [
       "one\r\ntwo",
       "\r\n",
       "\033[2mone\033[22m\r\n\033[2mtwo\033[22m",
     ];
-
     yield 'empty_eol_falls_back_to_newline' => [
       "one\ntwo",
       '',
       "\033[2mone\033[22m\n\033[2mtwo\033[22m",
     ];
+  }
+
+  /**
+   * Runs a callback and returns what it wrote to STDOUT.
+   *
+   * @param callable $callback
+   *   The callback to run.
+   *
+   * @return string
+   *   Everything the callback wrote to STDOUT.
+   */
+  protected function captureStdout(callable $callback): string {
+    $name = 'phpunit_helpers_stream_capture';
+
+    if (!in_array($name, stream_get_filters(), TRUE)) {
+      stream_filter_register($name, StreamCaptureFilter::class);
+    }
+
+    StreamCaptureFilter::$captured = '';
+
+    $filter = stream_filter_append(STDOUT, $name, STREAM_FILTER_WRITE);
+    if ($filter === FALSE) {
+      throw new \RuntimeException('Unable to attach the capture filter to STDOUT.');
+    }
+
+    try {
+      $callback();
+    }
+    finally {
+      stream_filter_remove($filter);
+    }
+
+    return StreamCaptureFilter::$captured;
+  }
+
+  protected function makeStreamingCaptureCallback(string &$captured_output): callable {
+    return function ($type, $buffer) use (&$captured_output): void {
+      $prefix = $type === Process::ERR ? self::$processStreamingErrorOutputChars : self::$processStreamingStandardOutputChars;
+
+      $parts = preg_split('/(\r\n|\n|\r)/', $buffer, -1, PREG_SPLIT_DELIM_CAPTURE);
+      $count = is_array($parts) ? count($parts) : 0;
+
+      for ($i = 0; $i < $count; $i += 2) {
+        $line = $parts[$i] ?? '';
+        $eol = $parts[$i + 1] ?? '';
+
+        if ($line === '' && $eol === '') {
+          continue;
+        }
+
+        $captured_output .= $prefix . $line . $eol;
+      }
+    };
   }
 
 }

--- a/tests/Unit/SerializableClosureTraitTest.php
+++ b/tests/Unit/SerializableClosureTraitTest.php
@@ -38,10 +38,6 @@ final class SerializableClosureTraitTest extends TestCase {
     $this->assertSame('test', $actual());
   }
 
-  public function fixtureCallable(): string {
-    return 'test';
-  }
-
   public function testCwCallable(): void {
     $actual = self::cw($this->fixtureCallable(...));
 
@@ -60,6 +56,10 @@ final class SerializableClosureTraitTest extends TestCase {
 
     $this->assertInstanceOf(\Closure::class, $actual);
     $this->assertSame('test', $actual());
+  }
+
+  public function fixtureCallable(): string {
+    return 'test';
   }
 
 }

--- a/tests/Unit/StringTraitTest.php
+++ b/tests/Unit/StringTraitTest.php
@@ -17,7 +17,6 @@ final class StringTraitTest extends UnitTestCase {
 
   #[DataProvider('dataProviderAssertStringContainsOrNot')]
   public function testAssertStringContainsOrNot(
-    string $name,
     string $haystack,
     array|string $expected,
     bool $case_insensitive,
@@ -66,7 +65,6 @@ final class StringTraitTest extends UnitTestCase {
 
   public static function dataProviderAssertStringContainsOrNot(): \Iterator {
     yield 'shortcut_mode_substring_matching' => [
-      'shortcut_mode_substring_matching',
       'This is a test string with some content',
       ['test', 'string', 'content'],
       TRUE,
@@ -76,7 +74,6 @@ final class StringTraitTest extends UnitTestCase {
       NULL,
     ];
     yield 'mixed_mode_all_prefixes' => [
-      'mixed_mode_all_prefixes',
       'apple pie banana split',
       ['* apple', '* pie', '! orange', '! cake'],
       TRUE,
@@ -86,7 +83,6 @@ final class StringTraitTest extends UnitTestCase {
       NULL,
     ];
     yield 'present_matching' => [
-      'present_matching',
       'apple pie and banana split',
       ['* apple', '* pie'],
       TRUE,
@@ -96,7 +92,6 @@ final class StringTraitTest extends UnitTestCase {
       NULL,
     ];
     yield 'absent_matching' => [
-      'absent_matching',
       'apple pie and banana split',
       ['- orange', '! cake'],
       TRUE,
@@ -106,7 +101,6 @@ final class StringTraitTest extends UnitTestCase {
       NULL,
     ];
     yield 'case_insensitive_matching' => [
-      'case_insensitive_matching',
       'Apple PIE and Banana SPLIT',
       ['* apple', '* pie', '! ORANGE'],
       TRUE,
@@ -116,7 +110,6 @@ final class StringTraitTest extends UnitTestCase {
       NULL,
     ];
     yield 'case_sensitive_matching' => [
-      'case_sensitive_matching',
       'Apple PIE and Banana SPLIT',
       ['* Apple', '* PIE', '! apple'],
       FALSE,
@@ -126,7 +119,6 @@ final class StringTraitTest extends UnitTestCase {
       NULL,
     ];
     yield 'single_string_input' => [
-      'single_string_input',
       'This is a test string',
       '* test',
       TRUE,
@@ -136,7 +128,6 @@ final class StringTraitTest extends UnitTestCase {
       NULL,
     ];
     yield 'empty_expected_array' => [
-      'empty_expected_array',
       'This is a test string',
       [],
       TRUE,
@@ -146,7 +137,6 @@ final class StringTraitTest extends UnitTestCase {
       NULL,
     ];
     yield 'complex_real_world_scenario' => [
-      'complex_real_world_scenario',
       'The quick brown fox jumps over the lazy dog. Error: file not found.',
       [
         '* quick',
@@ -165,7 +155,6 @@ final class StringTraitTest extends UnitTestCase {
       NULL,
     ];
     yield 'invalid_prefix_length' => [
-      'invalid_prefix_length',
       'test',
       ['* test'],
       TRUE,
@@ -175,7 +164,6 @@ final class StringTraitTest extends UnitTestCase {
       'All prefix arguments must be exactly one character long.',
     ];
     yield 'non_unique_prefixes' => [
-      'non_unique_prefixes',
       'test',
       ['* test'],
       TRUE,
@@ -185,7 +173,6 @@ final class StringTraitTest extends UnitTestCase {
       'All prefix arguments must be unique.',
     ];
     yield 'inconsistent_prefix_usage' => [
-      'inconsistent_prefix_usage',
       'test string',
       ['* test', 'string'],
       TRUE,
@@ -195,7 +182,6 @@ final class StringTraitTest extends UnitTestCase {
       'All strings must have valid prefixes in mixed mode. First invalid: "string"',
     ];
     yield 'empty_value_after_stripping_prefix' => [
-      'empty_value_after_stripping_prefix',
       'test',
       ['+ '],
       TRUE,
@@ -205,7 +191,6 @@ final class StringTraitTest extends UnitTestCase {
       'Value cannot be empty after stripping prefix: "+ "',
     ];
     yield 'present_failure' => [
-      'present_failure',
       'apple pie',
       ['* nonexistent'],
       TRUE,
@@ -215,7 +200,6 @@ final class StringTraitTest extends UnitTestCase {
       NULL,
     ];
     yield 'absent_failure' => [
-      'absent_failure',
       'apple pie banana',
       ['! apple'],
       TRUE,
@@ -225,7 +209,6 @@ final class StringTraitTest extends UnitTestCase {
       NULL,
     ];
     yield 'case_sensitive_exact_match_present' => [
-      'case_sensitive_exact_match_present',
       'Hello',
       ['+ Hello'],
       FALSE,
@@ -235,7 +218,6 @@ final class StringTraitTest extends UnitTestCase {
       NULL,
     ];
     yield 'case_sensitive_substring_present' => [
-      'case_sensitive_substring_present',
       'Hello World',
       ['* Hello'],
       FALSE,
@@ -245,7 +227,6 @@ final class StringTraitTest extends UnitTestCase {
       NULL,
     ];
     yield 'case_sensitive_exact_match_absent' => [
-      'case_sensitive_exact_match_absent',
       'Hello World',
       ['- hello'],
       FALSE,
@@ -255,7 +236,6 @@ final class StringTraitTest extends UnitTestCase {
       NULL,
     ];
     yield 'case_sensitive_substring_absent' => [
-      'case_sensitive_substring_absent',
       'Hello World',
       ['! goodbye'],
       FALSE,
@@ -265,7 +245,6 @@ final class StringTraitTest extends UnitTestCase {
       NULL,
     ];
     yield 'custom_messages_with_exact_match' => [
-      'custom_messages_with_exact_match',
       'test',
       ['+ test'],
       TRUE,
@@ -275,7 +254,6 @@ final class StringTraitTest extends UnitTestCase {
       NULL,
     ];
     yield 'empty_separator_mixed_mode_present_exact' => [
-      'empty_separator_mixed_mode_present_exact',
       'apple',
       ['+apple'],
       TRUE,
@@ -285,7 +263,6 @@ final class StringTraitTest extends UnitTestCase {
       NULL,
     ];
     yield 'empty_separator_mixed_mode_present_contains' => [
-      'empty_separator_mixed_mode_present_contains',
       'This contains apple and banana',
       ['*apple', '*banana'],
       TRUE,
@@ -295,7 +272,6 @@ final class StringTraitTest extends UnitTestCase {
       NULL,
     ];
     yield 'empty_separator_mixed_mode_absent_exact' => [
-      'empty_separator_mixed_mode_absent_exact',
       'apple',
       ['-orange'],
       TRUE,
@@ -305,7 +281,6 @@ final class StringTraitTest extends UnitTestCase {
       NULL,
     ];
     yield 'empty_separator_mixed_mode_absent_contains' => [
-      'empty_separator_mixed_mode_absent_contains',
       'This contains apple and banana',
       ['!orange', '!grape'],
       TRUE,
@@ -315,7 +290,6 @@ final class StringTraitTest extends UnitTestCase {
       NULL,
     ];
     yield 'empty_separator_inconsistent_prefix_usage' => [
-      'empty_separator_inconsistent_prefix_usage',
       'test string',
       ['*test', 'string'],
       TRUE,
@@ -325,7 +299,6 @@ final class StringTraitTest extends UnitTestCase {
       'All strings must have valid prefixes in mixed mode. First invalid: "string"',
     ];
     yield 'empty_separator_empty_value_after_stripping' => [
-      'empty_separator_empty_value_after_stripping',
       'test',
       ['+'],
       TRUE,

--- a/tests/Unit/UnitTestCaseTest.php
+++ b/tests/Unit/UnitTestCaseTest.php
@@ -47,13 +47,4 @@ final class UnitTestCaseTest extends UnitTestCase {
     $this->assertStringNotContainsString('contestableSituationInfo', $info);
   }
 
-  public function testInfoIncludesMethodsNotContainingTest(): void {
-    $info = $this->info();
-
-    $this->assertStringContainsString('First info value', $info);
-    $this->assertStringContainsString('42', $info);
-    $this->assertStringContainsString('"one","two","three"', $info);
-    $this->assertStringContainsString('This non-static info method should be included', $info);
-  }
-
 }


### PR DESCRIPTION
## Summary

A convergence pass over the whole codebase: read every first-party file, built one global map of how each concept is named and shaped, chose a single canonical form per concept, and rewrote the outliers. Behaviour-preserving throughout - every change is a rename, a shape alignment, or a de-duplication, and the test suite plus PHPCS, PHPStan level 9 and Rector are green after each commit.

Roughly 75 concepts appeared with more than one form. Most were left alone deliberately: this library is consumed via `composer require`, so anything that renames or reshapes a public symbol, or changes observable failure-message text, was reported rather than applied.

### Applied

**Naming**

- Test methods in `LoggerTraitTest` that used the trait *name* (`testLogger*`) now use its member prefix (`testLog*`), matching the 30+ methods already spelled that way and the prefix rule in `AGENTS.md`.
- The verbose-off scenario suffix is `SilentMode` everywhere, pairing with the existing `VerboseMode` positives.
- The "not initialized" scenario is spelled `WhenNotInitialized` across both execution-trait test files, replacing four competing spellings.
- Tests exercising a single `ContainsOrNot` assertion are named after that member; `Assertions` is now reserved for tests that genuinely exercise several. The multiline token settled on `Multiline`.
- Scenario-only test names that had one obvious member subject now lead with it.
- Method names no longer repeat their class subject (`testProcessTraitStreaming*`) or drop their member prefix (`testStreamingOutputWithDimming*`).

**Structure**

- Plain strings that needed no double quotes are single-quoted, per the project's own convention.
- Data provider yields are packed consistently.
- Helper methods sit at the end of their class rather than mid-file.
- `ProcessTrait`'s sprintf continuation indent matches `ApplicationTrait`'s (whitespace only - `git diff -w` on that file is empty).

**API shape**

- `ApplicationTrait` builds combined output in two statements, matching the four sibling sites including its own third one.
- `logGetOutputStream()` resolves its fallback with `??` like the other five fallback sites.
- `assertStringContainsOrNot()` documents the assertion failure it can throw, as the other assertion methods do.
- One test expected `AssertionFailedError` where the wrapped assertion throws `ExpectationFailedException`; tightened to the exact class. The other 13 sites were already precise per mechanism and were left alone.
- Guard/skip message literals in tests end with a period, matching `src/`.

**Architecture**

- Tests call the library's own `callProtectedMethod()` instead of hand-rolled `\ReflectionClass` where the helper supports the case. Sites that address *static* properties keep raw reflection - the helpers take an object and cannot reach them.
- A property written via reflection in one test is now assigned directly, as it already is at three other sites in the same file.
- Duplicated blocks extracted: the streaming-capture closure (4 copies), the log-buffer recreation block (5 copies).
- Near-identical tests folded into existing or new data providers, per the project's "prefer data providers" rule.
- Two tests whose assertions were strict subsets of another test were removed.
- State restoration moved into `finally` so it survives a failing assertion.

### Comment register

A separate pass over every source file, run after the convergence commits so it saw the final symbol names. It applies one rule: a comment justifies code, it never restates it.

**82 comments deleted, 18 reworded, 223 left alone.**

The largest single group was `LoggerTraitTest`, which carried a one-line docblock on every method - `Test logSection method.` above `testLogSection()` and so on, around 48 of them. They told the reader nothing the signature did not. The two sibling test files in the same directory already had none.

No claim was changed. Where a comment turned out to be factually wrong, it was left in place and reported below, because correcting a claim is a substantive change that deserves its own review rather than being buried in a wording diff.

One code change came out of this pass and is committed separately: deleting four comments in `applicationRun()` that restated the `if (!$expect_fail)` guard exposed two `catch` blocks with identical bodies. Since `\RuntimeException` descends from `\Exception`, the first was already fully subsumed by the second, so it was removed.

## Not applied - judgment calls left to you

These are the calls the pass deliberately did not make. Each lists the competing forms.

### Public API - would break consumers

| Concept | Forms |
|---|---|
| `assertStringContainsOrNot()` signature and visibility | `protected`, four positional message templates mid-signature vs the 26 other assertions: `public` with a trailing `?string $message = NULL` |
| Trait constant prefix | `TUI_DEFAULT`/`TUI_SKIP` prefixed vs `KEYS`, `BASELINE_DATASET`, `BASELINE_DIR` unprefixed. `AGENTS.md` states the prefix rule for methods and properties and is silent on constants - that silence is yours to resolve |
| `$processStreamingOutput` vs `$applicationShowOutput` | Same role, two names - though they also describe genuinely different mechanisms |
| `Output` vs `StandardOutput` in member names | 12 vs 3 |
| `processFormatOutput()` vs the `<prefix>Info()` family | Renaming it to `processInfo()` would make `UnitTestCase::info()`'s `*Info` suffix discovery pick it up, changing every failure message |
| `locationsFixturesDir()` vs `locationsFixtureDir()` | One letter apart, different jobs - a naming hazard worth fixing at the next major |
| `tuiEntryToKeystroke()` | Singular name, returns an array |
| `AssertArrayTrait` vs `StringTrait` | Verb-first vs noun-only, both assertion-only traits |
| Untyped-but-typeable `$tuiYes`/`$tuiNo` | Adding a native type to a trait property is a compatibility change for consumers who redeclare it |
| Three customization mechanisms | Overridable static method vs protected static property vs public static properties |
| Duplicated init tail in `ApplicationTrait`; `StringTrait`'s prefix scan repeated 3x | Extraction adds new members to published traits, which land in every consumer class |

### Would change behaviour

| Concept | Why left alone |
|---|---|
| **`assertionSuffix()`** - appended at 20 sites in `ProcessTrait`, nowhere else | Per your instruction, not added anywhere. Removing it instead would change `ProcessTrait`'s failure output, which `ProcessTraitFunctionalTest` asserts. Neither direction taken |
| `$message` semantics, guard handling, the Successful/Failed mechanism, combined-output wording | Each changes the text or exception class of observable failure output that tests assert |
| No trailing period on the `ContainsOrNot` template family | Internally consistent across all three traits; in `ProcessTrait` the templates are immediately followed by `assertionSuffix()`, so a period would land mid-composition |
| Message placeholder quoting (`"%s"` / `'%s'` / bare `%s`) | Normalizing rewrites emitted strings that tests match on |
| `\InvalidArgumentException` vs `\RuntimeException` for a missing path | Changes what consumer catch blocks see |
| `print` vs `fwrite(STDOUT)`; `PHP_EOL` vs `\n` | `print` goes through output buffering and `fwrite` does not, so they land in different places |
| `EnvTrait` registry vs `getenv()` split | `envUnsetPrefix` can unset system variables the trait never set, and `envReset` cannot restore them |
| `logStepStart`/`logStepFinish` backtrace duplication | Extracting a helper shifts the backtrace depth and would silently change every inferred step name |
| `tearDown` post-state and run-method failure handling | Documented behavioural contracts of the two traits |
| `assertEquals` at `TuiTraitTest.php:27` | It is masking a real mismatch - see defects below |

### Genuine ties - no dominant form

Expected-failure token placement in `ApplicationTraitTest` names (4 spellings, 1 each); `*Info()` line accumulation (array+implode vs string `.=`); docblock array generics vs bare `array`; per-channel test trios that each exercise a different method; scenario/provider coverage overlaps; anonymous vs named command fixtures; in-band provider sentinels; the four `Functional` class-name meanings.

### Documentation drift - belongs to a docs pass, not this one

`AGENTS.md` documents `#[CoversClass(ClassName::class)]` and `#[DataProvider('providerMethodName')]`. The code uses `#[CoversTrait]` on all 10 trait test classes (correct PHPUnit usage) and names all 28 providers `dataProvider<X>`. **The docs are out of step with the code, not the reverse.**

## Comments that are factually wrong - reported, not fixed

Twelve comments assert something the code does not do. None were corrected.

| Location | Says | Actually |
|---|---|---|
| `src/UnitTestCase.php:100` | `assertionSuffix()` is a "Suffix to be added to **all** assertion failure messages" | Only `ProcessTrait` appends it. `AssertArrayTrait`, `StringTrait` and `ApplicationTrait` build failure messages without it |
| `src/Traits/ApplicationTrait.php:554` | `@param` for `assertApplicationAnyOutputContainsOrNot()` says "combined **process** output" | It checks the application tester's display plus error output. Every sibling says "application output" - "process" is carried over from `ProcessTrait` |
| `src/Traits/LocationsTrait.php:40` | `$fixtures` holds a "Path to the fixtures directory **from the root** of this project" | `locationsInit()` stores an absolute realpath, or leaves it `NULL`. Only `locationsFixturesDir()` returns a root-relative path |
| `src/Traits/LocationsTrait.php:208` | `$exclude` is "An array of excluded **directories or files**" | It feeds `Finder::exclude()`, which excludes directories only. A plain file name listed there is still copied |
| `src/Traits/TuiTrait.php:45` | `KEYS` maps keys to "escape sequences" | Several values are not escape sequences: plain characters, the DEL byte, and control bytes |
| `src/Traits/TuiTrait.php:188` | Clearing and accepting are "handled by the consumer" for entries with a special key | The check excludes SPACE, so an entry whose only special key is a space still gets those keystrokes appended by `tuiKeystrokes()` itself |
| `tests/Unit/ApplicationTraitTest.php:159` | The test "only verifies the application runs successfully" | It also asserts output content |
| `tests/Unit/LoggerTraitTest.php` (4 deleted docblocks) | "Test verbose mode setter **and getter**"; three others promise "visual output for inspection" | There is no verbose getter. And `setUp()` routes output into an in-memory buffer the test reads back - nothing reaches a console |
| `tests/Unit/LoggerTraitTest.php` (deleted docblock) | "Test `logStepSummary` **with custom title**" | `logStepSummary(string $indent = '  ')` has no title parameter, and the test passes no arguments. **The method name `testLogStepSummaryWithCustomTitle` carries the same misnomer** - left alone because it is code, not a comment |

## Defects found - reported, not fixed

Each of these needs a decision, so none were touched.

1. **Stacked `expectExceptionMessage()` calls** - `tests/Unit/ProcessTraitTest.php`, two tests call it twice; PHPUnit keeps only the last, so the `PROCESS FAILED` / `PROCESS SUCCEEDED` expectation is dead and only the `Message: ...` substring is actually asserted. The tests assert less than they read as asserting.

2. **`AssertArrayTrait` mirrored pair behaves asymmetrically** - `assertArrayContainsString` casts every element with `(string) $hay`, so a non-Stringable object in the haystack is a fatal error; `assertArrayNotContainsString` skips objects instead. The positive array assertion uses `assertTrue($found)`, the negative uses `fail()`. Same input, different behaviour, on public mirrored assertions.

3. **`tuiEntries()` does not stringify scalars** - the `with_scalar_values` provider rows expect `'123'`/`'45.6'`/`'1'` but the method returns the original int/float/bool. The test passes only because it is the file's single `assertEquals`; switching to the codebase-standard `assertSame` fails it. Either the method should cast or the expectations should carry native types.

4. **Dead partial mock** - `tests/Unit/LocationsTraitTest.php`, a partial mock of `locationsFixturesDir()` is configured but never invoked, and `locationsInit` is called through `ReflectionMethod` although the method is public. Resolving it would also let the class become `final` - it is the only non-final test class, and it is non-final *because* of this mock.

5. **Vacuous self-assertion** - `tests/Unit/ApplicationTraitTest.php`, `testApplicationRunWithShowOutput` sets `$this->applicationShowOutput = TRUE`, asserts its own assignment, then resets to `FALSE` before running. The show-output path is never exercised; the assertion tests PHP's assignment operator.

## One convergence reverted

`assertInstanceOf(Application::class, $this->application)` appears twice in `testApplicationInitFromCommandWithDefaultName` and looks like copy-paste. It is not: PHPStan's narrowing does not survive the intervening call, and removing the second occurrence fails level 9 with `Cannot call method all() on Application|null`. The lint gate caught it and the change was reverted.

## A note on the suite

While running the gate repeatedly on identical trees I saw the assertion count vary (1411, 1412, 1414, 1415 for the same code), while the test count stayed fixed. Something in the suite contributes a variable number of assertions run to run. It never affected pass/fail, so it did not block anything here, but it is worth a look - a suite whose assertion count is not reproducible can hide a regression.

## Test plan

- [ ] `composer test` green - 476 tests, up from 474 (one duplicate test removed, two Logger tests folded into a five-row provider)
- [ ] `composer lint` green (PHPCS 32/32, PHPStan level 9, Rector)
- [ ] CI green across PHP 8.2 / 8.3 / 8.4 / 8.5, normal and lowest dependencies
- [ ] Public API unchanged - no trait, method, property or constant renamed; no signature or visibility altered
- [ ] No failure-message text changed

## Before / After

`ApplicationTrait::applicationRun()` caught `\RuntimeException` and `\Exception` separately, with the same guard and the same two comments restating it in both blocks. `\RuntimeException` already descends from `\Exception`, so the first block was dead weight - the second always covered it.

```
 BEFORE                                        AFTER
 ┌──────────────────────────────────────┐      ┌──────────────────────────────────────┐
 │ catch (\RuntimeException $exception) {│      │ catch (\Exception $exception) {       │
 │   // Expected to succeed, but failed. │      │   if (!$expect_fail) {                │
 │   if (!$expect_fail) {                │      │     throw new AssertionFailedError(   │
 │     throw new AssertionFailedError(   │      │       ...                             │
 │       ...                             │      │     );                                │
 │     );                                │      │   }                                   │
 │   }                                   │      │   $output = $exception->getMessage(); │
 │   // Expected to fail, so capture     │      │ }                                     │
 │   // the output.                      │      └──────────────────────────────────────┘
 │   $output = $exception->getMessage(); │
 │ }                                     │           one block, no comments -
 │ catch (\Exception $exception) {       │           the guard already reads
 │   if (!$expect_fail) {                │           as what it does
 │     // Expected to succeed, but       │
 │     // failed.                        │
 │     throw new AssertionFailedError(   │
 │       ...                             │
 │     );                                │
 │   }                                   │
 │   // Expected to fail, so capture     │
 │   // the output.                      │
 │   $output = $exception->getMessage(); │
 │ }                                     │
 └──────────────────────────────────────┘
        two blocks, four comments -
        \RuntimeException path was
        already unreachable dead code
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Standardized naming, formatting, providers, comments, helper placement, and test structure.
- Replaced supported reflection usage with `callProtectedMethod()`.
- Extracted shared test setup and streaming callbacks.
- Consolidated duplicate test cases with data providers.
- Added cleanup guards with `finally`.
- Removed redundant tests and 82 comments. Reworded 18 comments.
- Simplified `applicationRun()` by removing a subsumed `RuntimeException` catch block.
- Preserved public APIs, behavior, failure messages, visibility, and documented contracts.

## Validation

The test plan covers PHPUnit, PHPCS, PHPStan level 9, Rector, and CI on PHP 8.2–8.5 with normal and lowest dependencies.

## Possibly related

Issue references were not identified in the available repository issue search results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->