### PR TITLE
Appended the assertion suffix centrally instead of at each call site.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     },
     "require": {
         "php": ">=8.3",
-        "phpunit/phpunit": "^11.2 || ^12 || ^13",
+        "phpunit/phpunit": "^12.5.24 || ^13",
         "symfony/filesystem": "^6.4 || ^7.2",
         "symfony/finder": "^6.4 || ^7.2",
         "symfony/process": "^6.4 || ^7.2"

--- a/src/Traits/ProcessTrait.php
+++ b/src/Traits/ProcessTrait.php
@@ -372,7 +372,7 @@ trait ProcessTrait {
     $this->assertNotNull($this->process, 'Process is not initialized.');
 
     if (!$this->process->isSuccessful()) {
-      $this->fail('PROCESS FAILED' . PHP_EOL . ($message ? 'Message: ' . $message . PHP_EOL : '') . $this->processFormatOutput() . $this->assertionSuffix());
+      $this->fail('PROCESS FAILED' . PHP_EOL . ($message ? 'Message: ' . $message . PHP_EOL : '') . $this->processFormatOutput());
     }
   }
 
@@ -390,7 +390,7 @@ trait ProcessTrait {
     $this->assertNotNull($this->process, 'Process is not initialized.');
 
     if ($this->process->isSuccessful()) {
-      $this->fail('PROCESS SUCCEEDED but failure was expected' . PHP_EOL . ($message ? 'Message: ' . $message . PHP_EOL : '') . $this->processFormatOutput() . $this->assertionSuffix());
+      $this->fail('PROCESS SUCCEEDED but failure was expected' . PHP_EOL . ($message ? 'Message: ' . $message . PHP_EOL : '') . $this->processFormatOutput());
     }
   }
 
@@ -448,7 +448,7 @@ trait ProcessTrait {
           PHP_EOL,
           PHP_EOL,
           $output
-        ) . $this->assertionSuffix());
+        ));
       }
     }
   }
@@ -475,7 +475,7 @@ trait ProcessTrait {
           PHP_EOL,
           PHP_EOL,
           $output
-        ) . $this->assertionSuffix());
+        ));
       }
     }
   }
@@ -502,7 +502,7 @@ trait ProcessTrait {
           PHP_EOL,
           PHP_EOL,
           $output
-        ) . $this->assertionSuffix());
+        ));
       }
     }
   }
@@ -529,7 +529,7 @@ trait ProcessTrait {
           PHP_EOL,
           PHP_EOL,
           $output
-        ) . $this->assertionSuffix());
+        ));
       }
     }
   }
@@ -570,10 +570,10 @@ trait ProcessTrait {
     $this->assertStringContainsOrNot(
       $output,
       $expected,
-      $message ?: "Process output exact match failed for '%s'" . $this->assertionSuffix(),
-      $message ?: "Process output does not contain '%s'" . $this->assertionSuffix(),
-      $message ?: "Process output should not exactly match '%s'" . $this->assertionSuffix(),
-      $message ?: "Process output contains '%s' but should not" . $this->assertionSuffix()
+      $message ?: "Process output exact match failed for '%s'",
+      $message ?: "Process output does not contain '%s'",
+      $message ?: "Process output should not exactly match '%s'",
+      $message ?: "Process output contains '%s' but should not"
     );
   }
 
@@ -613,10 +613,10 @@ trait ProcessTrait {
     $this->assertStringContainsOrNot(
       $output,
       $expected,
-      $message ?: "Process error output exact match failed for '%s'" . $this->assertionSuffix(),
-      $message ?: "Process error output does not contain '%s'" . $this->assertionSuffix(),
-      $message ?: "Process error output should not exactly match '%s'" . $this->assertionSuffix(),
-      $message ?: "Process error output contains '%s' but should not" . $this->assertionSuffix()
+      $message ?: "Process error output exact match failed for '%s'",
+      $message ?: "Process error output does not contain '%s'",
+      $message ?: "Process error output should not exactly match '%s'",
+      $message ?: "Process error output contains '%s' but should not"
     );
   }
 
@@ -646,7 +646,7 @@ trait ProcessTrait {
           PHP_EOL,
           PHP_EOL,
           $output
-        ) . $this->assertionSuffix());
+        ));
       }
     }
   }
@@ -677,7 +677,7 @@ trait ProcessTrait {
           PHP_EOL,
           PHP_EOL,
           $output
-        ) . $this->assertionSuffix());
+        ));
       }
     }
   }
@@ -720,10 +720,10 @@ trait ProcessTrait {
     $this->assertStringContainsOrNot(
       $output,
       $expected,
-      $message ?: "Process output exact match failed for '%s'" . $this->assertionSuffix(),
-      $message ?: "Process output does not contain '%s'" . $this->assertionSuffix(),
-      $message ?: "Process output should not exactly match '%s'" . $this->assertionSuffix(),
-      $message ?: "Process output contains '%s' but should not" . $this->assertionSuffix()
+      $message ?: "Process output exact match failed for '%s'",
+      $message ?: "Process output does not contain '%s'",
+      $message ?: "Process output should not exactly match '%s'",
+      $message ?: "Process output contains '%s' but should not"
     );
   }
 

--- a/src/UnitTestCase.php
+++ b/src/UnitTestCase.php
@@ -6,6 +6,7 @@ namespace AlexSkrypnyk\PhpunitHelpers;
 
 use AlexSkrypnyk\PhpunitHelpers\Traits\LocationsTrait;
 use AlexSkrypnyk\PhpunitHelpers\Traits\ReflectionTrait;
+use PHPUnit\Framework\AssertionFailedError;
 use PHPUnit\Framework\TestCase;
 use PHPUnit\Framework\TestStatus\Error;
 use PHPUnit\Framework\TestStatus\Failure;
@@ -97,16 +98,37 @@ abstract class UnitTestCase extends TestCase {
   }
 
   /**
-   * Suffix to be added to all assertion failure messages.
-   *
-   * Works around a PHPUnit limitation: onNotSuccessfulTest() cannot alter
-   * the message within the assertion Throwable.
+   * Suffix appended to every assertion failure message.
    *
    * @return string
    *   The assertion suffix.
    */
   protected function assertionSuffix(): string {
     return $this->info();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function invokeTestMethod(string $methodName, array $testArguments): mixed {
+    try {
+      return parent::invokeTestMethod($methodName, $testArguments);
+    }
+    catch (AssertionFailedError $exception) {
+      // runBare() is final and emits the failure event from its own catch
+      // block, so onNotSuccessfulTest() runs too late to change the reported
+      // message. This hook is called from inside that block.
+      $suffix = $this->assertionSuffix();
+
+      if ($suffix !== '') {
+        // Mutating the caught Throwable keeps its stack trace, so the failure
+        // still reports the assertion line rather than this method.
+        $property = new \ReflectionProperty(\Exception::class, 'message');
+        $property->setValue($exception, $exception->getMessage() . $suffix);
+      }
+
+      throw $exception;
+    }
   }
 
   /**

--- a/src/UnitTestCase.php
+++ b/src/UnitTestCase.php
@@ -98,10 +98,10 @@ abstract class UnitTestCase extends TestCase {
   }
 
   /**
-   * Suffix appended to every assertion failure message.
+   * Suffix appended to assertion failure messages.
    *
-   * PHPUnit 11 exposes no hook that can reach the message, so nothing is
-   * appended there.
+   * PHPUnit verifies expectException() after the test method returns, so a
+   * failure raised by that verification carries no suffix.
    *
    * @return string
    *   The assertion suffix.
@@ -120,8 +120,7 @@ abstract class UnitTestCase extends TestCase {
     catch (AssertionFailedError $exception) {
       // runBare() is final and emits the failure event from its own catch
       // block, so onNotSuccessfulTest() runs too late to change the reported
-      // message. This hook is called from inside that block, and PHPUnit 11
-      // has no equivalent, so it never calls this method there.
+      // message. This hook is called from inside that block.
       $suffix = $this->assertionSuffix();
 
       if ($suffix !== '') {

--- a/src/UnitTestCase.php
+++ b/src/UnitTestCase.php
@@ -100,6 +100,9 @@ abstract class UnitTestCase extends TestCase {
   /**
    * Suffix appended to every assertion failure message.
    *
+   * PHPUnit 11 exposes no hook that can reach the message, so nothing is
+   * appended there.
+   *
    * @return string
    *   The assertion suffix.
    */
@@ -117,7 +120,8 @@ abstract class UnitTestCase extends TestCase {
     catch (AssertionFailedError $exception) {
       // runBare() is final and emits the failure event from its own catch
       // block, so onNotSuccessfulTest() runs too late to change the reported
-      // message. This hook is called from inside that block.
+      // message. This hook is called from inside that block, and PHPUnit 11
+      // has no equivalent, so it never calls this method there.
       $suffix = $this->assertionSuffix();
 
       if ($suffix !== '') {

--- a/tests/Functional/ProcessTraitFunctionalTest.php
+++ b/tests/Functional/ProcessTraitFunctionalTest.php
@@ -6,6 +6,7 @@ namespace AlexSkrypnyk\PhpunitHelpers\Tests\Functional;
 
 use AlexSkrypnyk\PhpunitHelpers\UnitTestCase;
 use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Meta-test for ProcessTrait streaming and assertion suffix functionality.
@@ -25,13 +26,12 @@ final class ProcessTraitFunctionalTest extends UnitTestCase {
 
     // The onNotSuccessfulTest() debug output appears in stderr.
     $this->assertStringContainsString('Error: ', (string) $output['stderr']);
-    $this->assertStringContainsString('Additional information:', (string) $output['stderr']);
+    $this->assertAssertionSuffix((string) $output['stderr']);
 
     // Common failure output.
     $this->assertStringContainsString('PROCESS FAILED', (string) $combined);
     $this->assertStringContainsString('PROCESS SUCCEEDED but failure was expected', (string) $combined);
-    $this->assertStringContainsString('Additional information:', (string) $combined);
-    $this->assertStringContainsString('LOCATIONS', (string) $combined);
+    $this->assertAssertionSuffix((string) $combined);
     $this->assertStringContainsString('Tests: 4', (string) $combined);
     $this->assertStringContainsString('Failures: 2', (string) $combined);
 
@@ -65,8 +65,7 @@ final class ProcessTraitFunctionalTest extends UnitTestCase {
     // Common failure output still appears.
     $this->assertStringContainsString('PROCESS FAILED', (string) $combined);
     $this->assertStringContainsString('PROCESS SUCCEEDED but failure was expected', (string) $combined);
-    $this->assertStringContainsString('Additional information:', (string) $combined);
-    $this->assertStringContainsString('LOCATIONS', (string) $combined);
+    $this->assertAssertionSuffix((string) $combined);
     $this->assertStringContainsString('Tests: 4', (string) $combined);
     $this->assertStringContainsString('Failures: 2', (string) $combined);
 
@@ -181,7 +180,34 @@ final class ProcessTraitFunctionalTest extends UnitTestCase {
     }
 
     $final_output = implode('', array_column($final_phase, 'data'));
-    $this->assertStringContainsString('Additional information:', $final_output);
+    $this->assertAssertionSuffix($final_output);
+  }
+
+  /**
+   * Asserts the assertion suffix is present only where the runtime adds it.
+   *
+   * @param string $haystack
+   *   The output to search.
+   */
+  protected function assertAssertionSuffix(string $haystack): void {
+    if (!self::supportsAssertionSuffix()) {
+      $this->assertStringNotContainsString('Additional information:', $haystack);
+
+      return;
+    }
+
+    $this->assertStringContainsString('Additional information:', $haystack);
+    $this->assertStringContainsString('LOCATIONS', $haystack);
+  }
+
+  /**
+   * Whether the runtime appends the assertion suffix to failure messages.
+   *
+   * @return bool
+   *   TRUE when PHPUnit exposes the hook UnitTestCase appends from.
+   */
+  protected static function supportsAssertionSuffix(): bool {
+    return (new \ReflectionClass(TestCase::class))->hasMethod('invokeTestMethod');
   }
 
 }

--- a/tests/Functional/ProcessTraitFunctionalTest.php
+++ b/tests/Functional/ProcessTraitFunctionalTest.php
@@ -6,7 +6,6 @@ namespace AlexSkrypnyk\PhpunitHelpers\Tests\Functional;
 
 use AlexSkrypnyk\PhpunitHelpers\UnitTestCase;
 use PHPUnit\Framework\Attributes\CoversNothing;
-use PHPUnit\Framework\TestCase;
 
 /**
  * Meta-test for ProcessTrait streaming and assertion suffix functionality.
@@ -26,12 +25,13 @@ final class ProcessTraitFunctionalTest extends UnitTestCase {
 
     // The onNotSuccessfulTest() debug output appears in stderr.
     $this->assertStringContainsString('Error: ', (string) $output['stderr']);
-    $this->assertAssertionSuffix((string) $output['stderr']);
+    $this->assertStringContainsString('Additional information:', (string) $output['stderr']);
 
     // Common failure output.
     $this->assertStringContainsString('PROCESS FAILED', (string) $combined);
     $this->assertStringContainsString('PROCESS SUCCEEDED but failure was expected', (string) $combined);
-    $this->assertAssertionSuffix((string) $combined);
+    $this->assertStringContainsString('Additional information:', (string) $combined);
+    $this->assertStringContainsString('LOCATIONS', (string) $combined);
     $this->assertStringContainsString('Tests: 4', (string) $combined);
     $this->assertStringContainsString('Failures: 2', (string) $combined);
 
@@ -65,7 +65,8 @@ final class ProcessTraitFunctionalTest extends UnitTestCase {
     // Common failure output still appears.
     $this->assertStringContainsString('PROCESS FAILED', (string) $combined);
     $this->assertStringContainsString('PROCESS SUCCEEDED but failure was expected', (string) $combined);
-    $this->assertAssertionSuffix((string) $combined);
+    $this->assertStringContainsString('Additional information:', (string) $combined);
+    $this->assertStringContainsString('LOCATIONS', (string) $combined);
     $this->assertStringContainsString('Tests: 4', (string) $combined);
     $this->assertStringContainsString('Failures: 2', (string) $combined);
 
@@ -180,34 +181,7 @@ final class ProcessTraitFunctionalTest extends UnitTestCase {
     }
 
     $final_output = implode('', array_column($final_phase, 'data'));
-    $this->assertAssertionSuffix($final_output);
-  }
-
-  /**
-   * Asserts the assertion suffix is present only where the runtime adds it.
-   *
-   * @param string $haystack
-   *   The output to search.
-   */
-  protected function assertAssertionSuffix(string $haystack): void {
-    if (!self::supportsAssertionSuffix()) {
-      $this->assertStringNotContainsString('Additional information:', $haystack);
-
-      return;
-    }
-
-    $this->assertStringContainsString('Additional information:', $haystack);
-    $this->assertStringContainsString('LOCATIONS', $haystack);
-  }
-
-  /**
-   * Whether the runtime appends the assertion suffix to failure messages.
-   *
-   * @return bool
-   *   TRUE when PHPUnit exposes the hook UnitTestCase appends from.
-   */
-  protected static function supportsAssertionSuffix(): bool {
-    return (new \ReflectionClass(TestCase::class))->hasMethod('invokeTestMethod');
+    $this->assertStringContainsString('Additional information:', $final_output);
   }
 
 }

--- a/tests/Unit/UnitTestCaseTest.php
+++ b/tests/Unit/UnitTestCaseTest.php
@@ -6,6 +6,7 @@ namespace AlexSkrypnyk\PhpunitHelpers\Tests\Unit;
 
 use AlexSkrypnyk\PhpunitHelpers\Tests\Fixtures\InfoMethodsTrait;
 use AlexSkrypnyk\PhpunitHelpers\UnitTestCase;
+use PHPUnit\Framework\AssertionFailedError;
 use PHPUnit\Framework\Attributes\CoversClass;
 
 #[CoversClass(UnitTestCase::class)]
@@ -45,6 +46,39 @@ final class UnitTestCaseTest extends UnitTestCase {
 
     $this->assertStringNotContainsString('This method contains test in the middle and should be excluded', $info);
     $this->assertStringNotContainsString('contestableSituationInfo', $info);
+  }
+
+  public function testInvokeTestMethodAppendsSuffixToFailure(): void {
+    $message = '';
+
+    try {
+      $this->invokeTestMethod('fixtureFailingAssertion', []);
+    }
+    catch (AssertionFailedError $assertion_failed_error) {
+      $message = $assertion_failed_error->getMessage();
+    }
+
+    $this->assertStringContainsString('Failed asserting', $message);
+    $this->assertStringContainsString('Additional information:', $message);
+    $this->assertStringContainsString('First info value', $message);
+  }
+
+  public function testInvokeTestMethodLeavesPassingMethodAlone(): void {
+    $this->assertNull($this->invokeTestMethod('fixturePassingAssertion', []));
+  }
+
+  /**
+   * Fails an assertion so the suffix path runs.
+   */
+  public function fixtureFailingAssertion(): void {
+    $this->assertSame('expected', 'actual');
+  }
+
+  /**
+   * Returns without failing so the suffix path is skipped.
+   */
+  public function fixturePassingAssertion(): void {
+    $this->addToAssertionCount(1);
   }
 
 }


### PR DESCRIPTION
## Summary

`ProcessTrait` concatenated `$this->assertionSuffix()` into 20 of its own failure messages, but never declared or provided that method - it exists only on `UnitTestCase`. The README documents composing `ProcessTrait` into a plain `PHPUnit\Framework\TestCase`, and doing exactly that produced a fatal `Error: Call to undefined method ...::assertionSuffix()` in place of the assertion failure. Because it only fired on the failure path, a consumer's green suite looked healthy right up until a test legitimately failed and the diagnostics were replaced by a fatal error.

The suffix is now appended once, centrally, by `UnitTestCase`. `ProcessTrait` no longer references a method it does not own, and every assertion gains the context rather than only the ones `ProcessTrait` happens to raise.

## Changes

- `UnitTestCase` overrides `invokeTestMethod()` and appends the suffix to any caught `AssertionFailedError`.
- `ProcessTrait` drops all 20 concatenations, removing its undeclared dependency on the composing class.
- `composer.json` requires `phpunit/phpunit: ^12.5.24 || ^13`.
- `UnitTestCaseTest` gains two regression tests covering the append path and the untouched pass path.

### Why that hook

`runBare()` is `final` and emits the failure event from inside its own `catch`, so `onNotSuccessfulTest()` runs after the message has already been recorded - which is what the previous docblock complained about. `runTest()` is `private`, so it cannot be wrapped either. `invokeTestMethod()` is `protected` and is called from inside that same block, so a throwable rethrown from it is the one PHPUnit records.

### Why the PHPUnit constraint moved

`invokeTestMethod()` arrived in PHPUnit 13.0.0 and was backported to 12.5.24. Anything from 11.2 to 12.5.23 lacks it. Requiring `^12.5.24 || ^13` makes the hook always present, so the suffix is unconditional rather than dependent on which PHPUnit a consumer happens to resolve. `--prefer-lowest` now installs 12.5.24, meaning the lowest supported version exercises the same code path as the newest.

This is why raising the PHP floor to 8.3 had to land first: PHPUnit 12 requires PHP 8.3, so this constraint could not have been expressed while PHP 8.2 was supported.

### Why the message is mutated rather than replaced

Mutating the caught throwable preserves its stack trace, so the failure still reports the assertion's own line. Constructing a replacement exception also works, but reports the wrapper's line and pushes the real one into a `Caused by` block.

## Verified

- Failure output is unchanged: the `manual` group still emits the identical `LOCATIONS` diagnostic block, with the real assertion line in the trace.
- The README consumer scenario is fixed: composing `ProcessTrait` into a plain `TestCase` now yields a proper assertion failure with a useful message instead of a fatal error.
- Coverage improves: a plain `assertSame()` failure inside any `UnitTestCase` subclass now carries the context, which it never did before, and the `--- Expected / +++ Actual` comparison diff still renders.
- Green on both dependency sets - PHPUnit 12.5.24 (lowest) and 12.5.34 (normal).

## Known limits

- Failures raised by expectation verification carry no suffix. PHPUnit checks `expectException()` inside `runTest()` after `invokeTestMethod()` has returned, and `runTest()` is private, so there is no hook to reach them. This is not a regression - the previous per-call-site concatenation never covered those either - and the docblock now states it rather than implying full coverage.
- Consumers composing the traits without `UnitTestCase` get no suffix. They never could; previously they got a fatal error instead.

## Breaking changes

`phpunit/phpunit` now requires `^12.5.24 || ^13`. Consumers on PHPUnit 11, or on 12.0.0 through 12.5.23, must upgrade.

## Before / After

```
┌─ BEFORE ─────────────────────────────────────────────────────────────┐
│  ProcessTrait                                                        │
│    20 call sites concatenate $this->assertionSuffix()                │
│    ...but the trait neither declares nor provides that method        │
│                                                                      │
│  class MyTest extends TestCase { use ProcessTrait; }                 │
│    assertion fails ──► Error: Call to undefined method                │
│                        ::assertionSuffix()                           │
│                                                                      │
│  native assertSame() failure ──► no context                          │
│  suffix computed eagerly on every passing assertion                  │
└──────────────────────────────────────────────────────────────────────┘
                                  │
                                  ▼
┌─ AFTER ──────────────────────────────────────────────────────────────┐
│  UnitTestCase::invokeTestMethod()                                    │
│    one central append, on the failure path only                      │
│                                                                      │
│  ProcessTrait                                                        │
│    0 call sites; owns every member it references                     │
│                                                                      │
│  class MyTest extends TestCase { use ProcessTrait; }                 │
│    assertion fails ──► proper failure with the real message           │
│                                                                      │
│  native assertSame() failure ──► carries LOCATIONS context           │
│  suffix computed once, only when a test actually fails               │
└──────────────────────────────────────────────────────────────────────┘
```
