### PR TITLE
Raised the minimum PHP version to 8.3.

### DIFF
--- a/.github/workflows/test-php.yml
+++ b/.github/workflows/test-php.yml
@@ -31,7 +31,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['8.2', '8.3', '8.4', '8.5']
+        php-versions: ['8.3', '8.4', '8.5']
         deps: ['normal', 'lowest']
 
     steps:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -130,7 +130,7 @@ Tests carrying `#[Group('manual')]` are excluded from the default suite and are 
 
 GitHub Actions workflows test across:
 
-- PHP versions: 8.2, 8.3, 8.4, 8.5
+- PHP versions: 8.3, 8.4, 8.5
 - Dependency preferences: `normal` and `lowest`, which between them cover the supported PHPUnit range
 
 Key workflows:

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "source": "https://github.com/alexskrypnyk/phpunit-helpers"
     },
     "require": {
-        "php": ">=8.2",
+        "php": ">=8.3",
         "phpunit/phpunit": "^11.2 || ^12 || ^13",
         "symfony/filesystem": "^6.4 || ^7.2",
         "symfony/finder": "^6.4 || ^7.2",

--- a/rector.php
+++ b/rector.php
@@ -32,7 +32,7 @@ return RectorConfig::configure()
   ->withPaths([
     __DIR__ . '/**',
   ])
-  ->withPhpSets(php82: TRUE)
+  ->withPhpSets(php83: TRUE)
   ->withPreparedSets(
     deadCode: TRUE,
     codeQuality: TRUE,

--- a/rector.php
+++ b/rector.php
@@ -27,11 +27,13 @@ use Rector\Php71\Rector\Assign\AssignArrayToStringRector;
 use Rector\Php80\Rector\Switch_\ChangeSwitchToMatchRector;
 use Rector\Privatization\Rector\Class_\FinalizeTestCaseClassRector;
 use Rector\TypeDeclaration\Rector\StmtsAwareInterface\DeclareStrictTypesRector;
+use Rector\ValueObject\PhpVersion;
 
 return RectorConfig::configure()
   ->withPaths([
     __DIR__ . '/**',
   ])
+  ->withPhpVersion(PhpVersion::PHP_83)
   ->withPhpSets(php83: TRUE)
   ->withPreparedSets(
     deadCode: TRUE,


### PR DESCRIPTION
## Summary
- Raised the minimum supported PHP version from 8.2 to 8.3 and dropped PHP 8.2 from the CI matrix.
- Updated `composer.json`, `.github/workflows/test-php.yml`, `rector.php`, and `AGENTS.md` to reflect the new floor.
- Verified both the normal and lowest dependency sets install and pass on the new PHP 8.3 floor.

## Changes
- `composer.json`: raised the `php` constraint from `>=8.2` to `>=8.3`.
- `.github/workflows/test-php.yml`: dropped `'8.2'` from the `php-versions` matrix, leaving `['8.3', '8.4', '8.5']`.
- `rector.php`: switched `->withPhpSets(php82: TRUE)` to `->withPhpSets(php83: TRUE)`, so Rector modernises code against the PHP 8.3 baseline.
- `AGENTS.md`: updated the documented CI matrix line to match the new PHP version list.
- The `phpunit/phpunit` constraint stays `^11.2 || ^12 || ^13` and is deliberately untouched: PHPUnit 11.2 already supports PHP 8.3, so `composer update --prefer-lowest` on an 8.3 floor still resolves PHPUnit 11.2.0 rather than a newer minimum, so dropping PHP 8.2 does not narrow the PHPUnit range on its own - that is a separate decision left for a follow-up.

Verified locally:
- Normal dependency set (PHPUnit 12.5.34): `composer test` passes all 476 tests; `composer lint` is green, with PHPCS 32/32, PHPStan level 9 clean, and Rector reporting no changes under the new `php83` set.
- Lowest dependency set on the new PHP 8.3 floor (PHPUnit 11.2.0): all 476 tests pass.

## Breaking changes
This is a library consumed via `composer require`, so raising the PHP floor to 8.3 drops support for any consumer still on PHP 8.2, which warrants a major version release.

## Before / After

```
Before                                After
------                                -----
PHP floor:  >=8.2                     PHP floor:  >=8.3

CI matrix (php-versions x deps):      CI matrix (php-versions x deps):
  8.2 --- normal                        8.3 --- normal
  8.2 --- lowest                        8.3 --- lowest
  8.3 --- normal                        8.4 --- normal
  8.3 --- lowest                        8.4 --- lowest
  8.4 --- normal                        8.5 --- normal
  8.4 --- lowest                        8.5 --- lowest
  8.5 --- normal
  8.5 --- lowest
  = 4 versions x 2 dep sets = 8 legs    = 3 versions x 2 dep sets = 6 legs

Lowest-resolved PHPUnit (--prefer-lowest):
  11.2.0                                11.2.0  (unchanged)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Raise the minimum supported PHP version from 8.2 to 8.3.
- Remove PHP 8.2 from the CI matrix.
- Configure Rector explicitly for PHP 8.3.
- Update CI documentation in `AGENTS.md`.
- Keep the PHPUnit constraint at `^11.2 || ^12 || ^13`.

## Verification

- 476 tests passed with normal dependencies.
- 476 tests passed with lowest dependencies.
- PHPCS, PHPStan level 9, and Rector passed.

This is a breaking change for PHP 8.2 consumers and requires a major version release.

## Possibly related

- No related repository issue was identified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->